### PR TITLE
Nostr relay false stale detection

### DIFF
--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -103,6 +103,7 @@ interface RelayConnection {
   reconnectTimer: ReturnType<typeof setTimeout> | null;
   pingTimer: ReturnType<typeof setInterval> | null;
   lastPongTime: number;
+  lastPingSentTime: number;
   wasConnected: boolean;  // Track if this relay was previously connected (for reconnect vs initial connect)
 }
 
@@ -264,6 +265,7 @@ export class NostrClient {
             reconnectTimer: null,
             pingTimer: null,
             lastPongTime: Date.now(),
+            lastPingSentTime: 0,
             wasConnected: existingRelay?.wasConnected ?? false,
           };
 
@@ -396,18 +398,28 @@ export class NostrClient {
         return;
       }
 
-      // Check if we've received any message recently
-      const timeSinceLastPong = Date.now() - relay.lastPongTime;
+      const now = Date.now();
+      const timeSinceLastPong = now - relay.lastPongTime;
+
       if (timeSinceLastPong > this.pingIntervalMs * 2) {
-        // Connection is stale - force close and reconnect
-        console.warn(`Relay ${url} appears stale (no response for ${timeSinceLastPong}ms), reconnecting...`);
-        this.stopPingTimer(url);
-        try {
-          relay.socket.close();
-        } catch {
-          // Ignore close errors
+        // Only declare stale if we actually sent a ping recently.
+        // If the timer was throttled (e.g., browser tab backgrounded), the interval
+        // may fire much later than expected. In that case, we haven't sent a ping
+        // recently, so we can't conclude the relay is stale — just send a new ping
+        // and check again on the next interval.
+        const timeSinceLastPing = now - relay.lastPingSentTime;
+        if (relay.lastPingSentTime > 0 && timeSinceLastPing < this.pingIntervalMs * 1.5) {
+          // We sent a ping recently and got no response - connection is truly stale
+          console.warn(`Relay ${url} appears stale (no response for ${timeSinceLastPong}ms), reconnecting...`);
+          this.stopPingTimer(url);
+          try {
+            relay.socket.close();
+          } catch {
+            // Ignore close errors
+          }
+          return;
         }
-        return;
+        // Timer was likely throttled — fall through to send a ping
       }
 
       // Send a subscription request as a ping (relays respond with EOSE)
@@ -421,6 +433,7 @@ export class NostrClient {
         // Then send the new ping request (limit:1 ensures relay sends EOSE)
         const pingMessage = JSON.stringify(['REQ', pingSubId, { limit: 1 }]);
         relay.socket.send(pingMessage);
+        relay.lastPingSentTime = now;
       } catch {
         // Send failed, connection likely dead
         console.warn(`Ping to ${url} failed, reconnecting...`);

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -103,7 +103,7 @@ interface RelayConnection {
   reconnectTimer: ReturnType<typeof setTimeout> | null;
   pingTimer: ReturnType<typeof setInterval> | null;
   lastPongTime: number;
-  lastPingSentTime: number;
+  unansweredPings: number;
   wasConnected: boolean;  // Track if this relay was previously connected (for reconnect vs initial connect)
 }
 
@@ -265,7 +265,7 @@ export class NostrClient {
             reconnectTimer: null,
             pingTimer: null,
             lastPongTime: Date.now(),
-            lastPingSentTime: 0,
+            unansweredPings: 0,
             wasConnected: existingRelay?.wasConnected ?? false,
           };
 
@@ -299,10 +299,11 @@ export class NostrClient {
           socket.onmessage = (event) => {
             try {
               const data = extractMessageData(event);
-              // Update last pong time on any message (relay is alive)
+              // Update last pong time and reset unanswered pings on any message (relay is alive)
               const r = this.relays.get(url);
               if (r) {
                 r.lastPongTime = Date.now();
+                r.unansweredPings = 0;
               }
               this.handleRelayMessage(url, data);
             } catch (error) {
@@ -398,28 +399,24 @@ export class NostrClient {
         return;
       }
 
-      const now = Date.now();
-      const timeSinceLastPong = now - relay.lastPongTime;
+      const timeSinceLastPong = Date.now() - relay.lastPongTime;
 
-      if (timeSinceLastPong > this.pingIntervalMs * 2) {
-        // Only declare stale if we actually sent a ping recently.
-        // If the timer was throttled (e.g., browser tab backgrounded), the interval
-        // may fire much later than expected. In that case, we haven't sent a ping
-        // recently, so we can't conclude the relay is stale — just send a new ping
-        // and check again on the next interval.
-        const timeSinceLastPing = now - relay.lastPingSentTime;
-        if (relay.lastPingSentTime > 0 && timeSinceLastPing < this.pingIntervalMs * 1.5) {
-          // We sent a ping recently and got no response - connection is truly stale
-          console.warn(`Relay ${url} appears stale (no response for ${timeSinceLastPong}ms), reconnecting...`);
-          this.stopPingTimer(url);
-          try {
-            relay.socket.close();
-          } catch {
-            // Ignore close errors
-          }
-          return;
+      if (timeSinceLastPong > this.pingIntervalMs * 2 && relay.unansweredPings >= 2) {
+        // No inbound message for 2x the ping interval AND we've sent at least 2 pings
+        // without any response — the connection is truly stale.
+        // The unanswered pings gate handles browser tab throttling: on the first tick
+        // after waking, unansweredPings is 0, so we send a ping and wait. If the relay
+        // is alive it responds (resetting the counter). If dead, subsequent ticks
+        // increment the counter until it reaches the threshold, even under sustained
+        // throttling where intervals are irregular.
+        console.warn(`Relay ${url} appears stale (no response for ${timeSinceLastPong}ms, ${relay.unansweredPings} unanswered pings), reconnecting...`);
+        this.stopPingTimer(url);
+        try {
+          relay.socket.close();
+        } catch {
+          // Ignore close errors
         }
-        // Timer was likely throttled — fall through to send a ping
+        return;
       }
 
       // Send a subscription request as a ping (relays respond with EOSE)
@@ -433,7 +430,7 @@ export class NostrClient {
         // Then send the new ping request (limit:1 ensures relay sends EOSE)
         const pingMessage = JSON.stringify(['REQ', pingSubId, { limit: 1 }]);
         relay.socket.send(pingMessage);
-        relay.lastPingSentTime = now;
+        relay.unansweredPings++;
       } catch {
         // Send failed, connection likely dead
         console.warn(`Ping to ${url} failed, reconnecting...`);

--- a/tests/unit/reconnection.test.ts
+++ b/tests/unit/reconnection.test.ts
@@ -6,6 +6,50 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { NostrClient, ConnectionEventListener } from '../../src/client/NostrClient.js';
 import { NostrKeyManager } from '../../src/NostrKeyManager.js';
 import { Filter } from '../../src/protocol/Filter.js';
+import type { IWebSocket, WebSocketMessageEvent, WebSocketCloseEvent, WebSocketErrorEvent } from '../../src/client/WebSocketAdapter.js';
+import { OPEN, CLOSED } from '../../src/client/WebSocketAdapter.js';
+
+// Mock createWebSocket to return a controllable fake socket
+vi.mock('../../src/client/WebSocketAdapter.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../src/client/WebSocketAdapter.js')>();
+  return {
+    ...orig,
+    createWebSocket: vi.fn(),
+  };
+});
+import { createWebSocket } from '../../src/client/WebSocketAdapter.js';
+const mockCreateWebSocket = vi.mocked(createWebSocket);
+
+/** Create a fake IWebSocket that captures handlers and tracks calls. */
+function createFakeSocket(): IWebSocket & {
+  _triggerOpen(): void;
+  _triggerMessage(data: string): void;
+  _triggerClose(code?: number, reason?: string): void;
+  sentMessages: string[];
+  closeCalls: Array<{ code?: number; reason?: string }>;
+  _readyState: number;
+} {
+  const socket: ReturnType<typeof createFakeSocket> = {
+    _readyState: OPEN,
+    get readyState() { return this._readyState; },
+    onopen: null,
+    onmessage: null,
+    onclose: null,
+    onerror: null,
+    sentMessages: [],
+    closeCalls: [],
+    send(data: string) { this.sentMessages.push(data); },
+    close(code?: number, reason?: string) {
+      this.closeCalls.push({ code, reason });
+      this._readyState = CLOSED;
+      if (this.onclose) this.onclose({ code: code ?? 1000, reason: reason ?? '' });
+    },
+    _triggerOpen() { if (this.onopen) this.onopen({}); },
+    _triggerMessage(data: string) { if (this.onmessage) this.onmessage({ data } as WebSocketMessageEvent); },
+    _triggerClose(code = 1000, reason = '') { this.close(code, reason); },
+  };
+  return socket;
+}
 
 describe('NostrClient Reconnection', () => {
   let client: NostrClient;
@@ -151,57 +195,115 @@ describe('NostrClient Reconnection', () => {
   });
 
   describe('ping health check logic', () => {
-    it('should detect stale connections after 2x ping interval when ping was sent recently', () => {
-      const pingInterval = 30000;
-      const staleThreshold = pingInterval * 2;
-      const now = Date.now();
+    const PING_INTERVAL = 15000;
+    let fakeSocket: ReturnType<typeof createFakeSocket>;
 
-      // Simulate last pong time exceeding threshold
-      const lastPongTime = now - (staleThreshold + 1000);
-      const timeSinceLastPong = now - lastPongTime;
+    async function connectClient(opts?: { pingIntervalMs?: number }): Promise<void> {
+      client = new NostrClient(keyManager, { pingIntervalMs: opts?.pingIntervalMs ?? PING_INTERVAL });
+      fakeSocket = createFakeSocket();
+      mockCreateWebSocket.mockResolvedValue(fakeSocket);
+      const connectPromise = client.connect('wss://relay.test');
+      // createWebSocket resolves, then onopen fires
+      await vi.advanceTimersByTimeAsync(0);
+      fakeSocket._triggerOpen();
+      await connectPromise;
+      // Clear any messages sent during connect (subscription reestablishment etc.)
+      fakeSocket.sentMessages.length = 0;
+    }
 
-      // Simulate a ping sent recently (within 1.5x interval)
-      const lastPingSentTime = now - pingInterval;
-      const timeSinceLastPing = now - lastPingSentTime;
+    it('should send ping REQ at each interval', async () => {
+      await connectClient();
 
-      // Both conditions must be true for stale detection
-      expect(timeSinceLastPong > staleThreshold).toBe(true);
-      expect(lastPingSentTime > 0 && timeSinceLastPing < pingInterval * 1.5).toBe(true);
+      await vi.advanceTimersByTimeAsync(PING_INTERVAL);
+      const pings = fakeSocket.sentMessages.filter(m => m.includes('"ping"'));
+      expect(pings.length).toBe(2); // CLOSE ping + REQ ping
+      expect(pings[0]).toBe(JSON.stringify(['CLOSE', 'ping']));
+      expect(pings[1]).toBe(JSON.stringify(['REQ', 'ping', { limit: 1 }]));
     });
 
-    it('should not detect fresh connections as stale', () => {
-      const pingInterval = 30000;
-      const staleThreshold = pingInterval * 2;
+    it('should close socket after 2 unanswered pings when relay is dead', async () => {
+      await connectClient();
 
-      // Simulate recent pong
-      const lastPongTime = Date.now() - 5000;
-      const timeSinceLastPong = Date.now() - lastPongTime;
+      // With 15s interval and 2x stale threshold (30s):
+      // Tick 1 (T=15s): timeSinceLastPong=15s ≤ 30s. Sends ping, unanswered=1.
+      await vi.advanceTimersByTimeAsync(PING_INTERVAL);
+      expect(fakeSocket.closeCalls.length).toBe(0);
 
-      expect(timeSinceLastPong > staleThreshold).toBe(false);
+      // Tick 2 (T=30s): timeSinceLastPong=30s ≤ 30s. Sends ping, unanswered=2.
+      await vi.advanceTimersByTimeAsync(PING_INTERVAL);
+      expect(fakeSocket.closeCalls.length).toBe(0);
+
+      // Tick 3 (T=45s): timeSinceLastPong=45s > 30s AND unanswered=2 ≥ 2 → STALE
+      await vi.advanceTimersByTimeAsync(PING_INTERVAL);
+      expect(fakeSocket.closeCalls.length).toBe(1);
     });
 
-    it('should not detect stale when timer was throttled (e.g., background tab)', () => {
-      const pingInterval = 30000;
-      const staleThreshold = pingInterval * 2;
-      const now = Date.now();
+    it('should not close socket when relay responds to pings', async () => {
+      await connectClient();
 
-      // Simulate tab backgrounded: last pong was 65s ago
-      const lastPongTime = now - 65000;
-      const timeSinceLastPong = now - lastPongTime;
+      // Run 10 ping cycles, responding to each one
+      for (let i = 0; i < 10; i++) {
+        await vi.advanceTimersByTimeAsync(PING_INTERVAL);
+        // Relay responds — resets unansweredPings and lastPongTime
+        fakeSocket._triggerMessage(JSON.stringify(['EOSE', 'ping']));
+      }
 
-      // But the last ping was also 65s ago (timer was throttled, no recent ping sent)
-      const lastPingSentTime = now - 65000;
-      const timeSinceLastPing = now - lastPingSentTime;
-
-      // Pong threshold exceeded, but ping wasn't sent recently — not truly stale
-      expect(timeSinceLastPong > staleThreshold).toBe(true);
-      expect(lastPingSentTime > 0 && timeSinceLastPing < pingInterval * 1.5).toBe(false);
+      expect(fakeSocket.closeCalls.length).toBe(0);
     });
 
-    it('should be disabled when pingIntervalMs is 0', () => {
-      client = new NostrClient(keyManager, { pingIntervalMs: 0 });
-      // Client created without error, ping is disabled
-      expect(client).toBeDefined();
+    it('should reset unanswered counter on any inbound message', async () => {
+      await connectClient();
+
+      // Tick 1 (T=15s): unanswered=1
+      await vi.advanceTimersByTimeAsync(PING_INTERVAL);
+      expect(fakeSocket.closeCalls.length).toBe(0);
+
+      // Tick 2 (T=30s): unanswered=2
+      await vi.advanceTimersByTimeAsync(PING_INTERVAL);
+      expect(fakeSocket.closeCalls.length).toBe(0);
+
+      // Before tick 3, relay sends a message — resets counter to 0 and updates lastPongTime
+      fakeSocket._triggerMessage(JSON.stringify(['EVENT', 'sub1', { id: '123' }]));
+
+      // Tick 3 (T=45s): timeSinceLastPong is small now, unanswered=0 → just sends ping
+      await vi.advanceTimersByTimeAsync(PING_INTERVAL);
+      expect(fakeSocket.closeCalls.length).toBe(0);
+
+      // Tick 4 (T=60s): unanswered=1 still under threshold
+      await vi.advanceTimersByTimeAsync(PING_INTERVAL);
+      expect(fakeSocket.closeCalls.length).toBe(0);
+    });
+
+    it('should close stale relay that stops responding mid-session', async () => {
+      await connectClient();
+
+      // Relay is alive for 5 cycles
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersByTimeAsync(PING_INTERVAL);
+        fakeSocket._triggerMessage(JSON.stringify(['EOSE', 'ping']));
+      }
+      expect(fakeSocket.closeCalls.length).toBe(0);
+
+      // Now relay stops responding — needs 3 more ticks (accumulate 2 unanswered + time threshold)
+      // Tick 6: unanswered=1, timeSinceLastPong=15s ≤ 30s
+      await vi.advanceTimersByTimeAsync(PING_INTERVAL);
+      expect(fakeSocket.closeCalls.length).toBe(0);
+
+      // Tick 7: unanswered=2, timeSinceLastPong=30s ≤ 30s
+      await vi.advanceTimersByTimeAsync(PING_INTERVAL);
+      expect(fakeSocket.closeCalls.length).toBe(0);
+
+      // Tick 8: unanswered=2, timeSinceLastPong=45s > 30s → STALE
+      await vi.advanceTimersByTimeAsync(PING_INTERVAL);
+      expect(fakeSocket.closeCalls.length).toBe(1);
+    });
+
+    it('should not send pings when pingIntervalMs is 0', async () => {
+      await connectClient({ pingIntervalMs: 0 });
+
+      await vi.advanceTimersByTimeAsync(120000);
+      expect(fakeSocket.sentMessages.length).toBe(0);
+      expect(fakeSocket.closeCalls.length).toBe(0);
     });
   });
 

--- a/tests/unit/reconnection.test.ts
+++ b/tests/unit/reconnection.test.ts
@@ -151,15 +151,22 @@ describe('NostrClient Reconnection', () => {
   });
 
   describe('ping health check logic', () => {
-    it('should detect stale connections after 2x ping interval', () => {
+    it('should detect stale connections after 2x ping interval when ping was sent recently', () => {
       const pingInterval = 30000;
       const staleThreshold = pingInterval * 2;
+      const now = Date.now();
 
-      // Simulate last pong time
-      const lastPongTime = Date.now() - (staleThreshold + 1000);
-      const timeSinceLastPong = Date.now() - lastPongTime;
+      // Simulate last pong time exceeding threshold
+      const lastPongTime = now - (staleThreshold + 1000);
+      const timeSinceLastPong = now - lastPongTime;
 
+      // Simulate a ping sent recently (within 1.5x interval)
+      const lastPingSentTime = now - pingInterval;
+      const timeSinceLastPing = now - lastPingSentTime;
+
+      // Both conditions must be true for stale detection
       expect(timeSinceLastPong > staleThreshold).toBe(true);
+      expect(lastPingSentTime > 0 && timeSinceLastPing < pingInterval * 1.5).toBe(true);
     });
 
     it('should not detect fresh connections as stale', () => {
@@ -171,6 +178,24 @@ describe('NostrClient Reconnection', () => {
       const timeSinceLastPong = Date.now() - lastPongTime;
 
       expect(timeSinceLastPong > staleThreshold).toBe(false);
+    });
+
+    it('should not detect stale when timer was throttled (e.g., background tab)', () => {
+      const pingInterval = 30000;
+      const staleThreshold = pingInterval * 2;
+      const now = Date.now();
+
+      // Simulate tab backgrounded: last pong was 65s ago
+      const lastPongTime = now - 65000;
+      const timeSinceLastPong = now - lastPongTime;
+
+      // But the last ping was also 65s ago (timer was throttled, no recent ping sent)
+      const lastPingSentTime = now - 65000;
+      const timeSinceLastPing = now - lastPingSentTime;
+
+      // Pong threshold exceeded, but ping wasn't sent recently — not truly stale
+      expect(timeSinceLastPong > staleThreshold).toBe(true);
+      expect(lastPingSentTime > 0 && timeSinceLastPing < pingInterval * 1.5).toBe(false);
     });
 
     it('should be disabled when pingIntervalMs is 0', () => {


### PR DESCRIPTION
## Summary

   Fix false stale relay detection when the browser tab is backgrounded or timers are otherwise throttled.

   **Problem:** The stale detection checked `timeSinceLastPong > pingIntervalMs * 2` and immediately closed the socket. When `setInterval` gets throttled
   (background tab, Android doze), the callback fires late with a large `timeSinceLastPong` — but no ping was sent during the throttled period, so the relay may
    be perfectly fine. The original `lastPingSentTime`-based fix had a further flaw: under sustained throttling (interval consistently fires at >= 1.5x
   `pingIntervalMs`), `timeSinceLastPing` always exceeded the window, so the stale path was never taken even with a truly dead relay.

   **Fix:** Replaced `lastPingSentTime` with an `unansweredPings` counter (incremented on each ping send, reset to 0 on any inbound message). The relay is
   declared stale only when both conditions hold:

   1. `timeSinceLastPong > pingIntervalMs * 2` — no inbound message for too long
   2. `unansweredPings >= 2` — at least 2 pings sent without any response

   This handles all throttling scenarios correctly:
   - **Normal operation:** counter reaches 2 after 2 unanswered pings on schedule
   - **Single wake from background:** counter is 0 on first tick, sends a ping and waits. If relay is alive, it responds and resets the counter. If dead, the
   next tick reaches the threshold
   - **Sustained throttling:** each tick (however irregular) increments the counter. After 2 unanswered ticks, stale is declared regardless of interval timing

   ## Test plan

   - [x] Replaced arithmetic-only unit tests with behavioral tests using a mocked `IWebSocket` and `vi.useFakeTimers()`
   - [x] Tests verify: ping REQ sent at each interval, dead relay closed after threshold, responsive relay stays connected, counter resets on any inbound
   message, mid-session relay death detected, no pings when disabled
   - [x] All 324 unit tests pass, typecheck clean