### PR TITLE
fix(client): scope keepalive ping, handle CLOSED frames, surface in queries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,10 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm
-        run: npm install -g npm@latest
+      # `npm install -g npm@latest` previously broke the publish step
+      # with `Cannot find module 'promise-retry'` (a regression in
+      # npm's bundled dep tree). Node 22 ships a working npm 10.x so
+      # the global upgrade is unnecessary.
 
       - name: Validate version format
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,14 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      # `npm install -g npm@latest` previously broke the publish step
-      # with `Cannot find module 'promise-retry'` (a regression in
-      # npm's bundled dep tree). Node 22 ships a working npm 10.x so
-      # the global upgrade is unnecessary.
+      # OIDC trusted publishing (configured on npmjs.com for this
+      # package) requires npm CLI ≥ 11.5. Node 22 ships with npm
+      # 10.x — too old. We pin to a known-working 11.x rather than
+      # `npm@latest` because some recent `latest` tarballs ship a
+      # broken bundled-dep tree (`Cannot find module 'promise-retry'`,
+      # see runs/25520859482).
+      - name: Pin npm to OIDC-capable version
+        run: npm install -g npm@11.5.2
 
       - name: Validate version format
         run: |
@@ -58,8 +62,24 @@ jobs:
             echo "tag=dev" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Publish to npm
-        run: npm publish --access public --tag ${{ steps.dist-tag.outputs.tag }}
+      - name: Publish to npm (OIDC trusted publishing)
+        # Trusted publishing flow:
+        #   1. The job's `id-token: write` permission lets GitHub
+        #      Actions mint an OIDC token bound to this workflow run.
+        #   2. npm CLI ≥ 11.5 trades that OIDC token for a short-lived
+        #      publish token at npmjs.com, which in turn checks the
+        #      configured trusted publisher (unicitynetwork/nostr-js-sdk
+        #      via .github/workflows/publish.yml) and approves.
+        #   3. `--provenance` attaches a build-attestation to the
+        #      published tarball — required when the npm side has
+        #      "Require 2FA or bypass-2fa token" enabled, since OIDC
+        #      with provenance is the way trusted publishing satisfies
+        #      that policy.
+        # We explicitly clear NODE_AUTH_TOKEN so npm doesn't fall back
+        # to legacy token auth (which would be rejected by the policy).
+        run: npm publish --access public --provenance --tag ${{ steps.dist-tag.outputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ''
 
       - name: Create git tag
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unicitylabs/nostr-js-sdk",
-  "version": "0.4.1",
+  "version": "0.5.0-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@unicitylabs/nostr-js-sdk",
-      "version": "0.4.1",
+      "version": "0.5.0-dev.2",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unicitylabs/nostr-js-sdk",
-  "version": "0.5.0-dev.2",
+  "version": "0.5.0-dev.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@unicitylabs/nostr-js-sdk",
-      "version": "0.5.0-dev.2",
+      "version": "0.5.0-dev.3",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicitylabs/nostr-js-sdk",
-  "version": "0.5.0-dev.2",
+  "version": "0.5.0-dev.3",
   "description": "Unicity Nostr SDK - Token transfers and nametag bindings over Nostr protocol",
   "license": "MIT",
   "author": "Unicity Labs",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:unit": "vitest run tests/unit",
-    "test:integration": "vitest run tests/integration",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicitylabs/nostr-js-sdk",
-  "version": "0.4.1",
+  "version": "0.5.0-dev.2",
   "description": "Unicity Nostr SDK - Token transfers and nametag bindings over Nostr protocol",
   "license": "MIT",
   "author": "Unicity Labs",

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -688,8 +688,25 @@ export class NostrClient {
 
     const message = typeof json[2] === 'string' ? json[2] : 'no reason provided';
 
+    // NIP-42 transient case: relays that require AUTH typically reject
+    // pre-auth REQs with `CLOSED("auth-required:...")` and then send
+    // an AUTH challenge. resubscribeAfterAuth re-issues the sub, so
+    // this rejection is NOT terminal. If we marked closedSubIds here:
+    //   1. queryWithFirstSeenWins.onError → allRelaysDoneFor → true
+    //      (single-relay case) → settles null + unsubscribes → the
+    //      sub is gone from the global Map by the time
+    //      resubscribeAfterAuth runs → no retry, query lost.
+    //   2. resubscribeAll on AUTH-success would skip this sub for
+    //      the brief window before resubscribeAfterAuth clears the
+    //      marker (hardened by the clear, but skip-then-clear is
+    //      fragile).
+    // Listener still gets onError so callers see the reason; we just
+    // don't poison the per-relay state with a transient marker.
+    const isAuthRequired = message.startsWith('auth-required:')
+        || message.startsWith('auth-required ');
+
     const relay = this.relays.get(relayUrl);
-    if (relay) {
+    if (relay && !isAuthRequired) {
       relay.closedSubIds.add(subscriptionId);
     }
 

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -641,10 +641,14 @@ export class NostrClient {
    * across all relays.
    */
   private handleClosedMessage(relayUrl: string, json: unknown[]): void {
-    if (json.length < 3) return;
+    // NIP-01 makes the message field optional: `["CLOSED", <sub>]` is
+    // valid. Dropping such frames was exactly the leak this PR sets out
+    // to fix — no closedSubIds marker and no onError notification means
+    // queries hang until timeout and resubscribe loops persist.
+    if (json.length < 2) return;
 
     const subscriptionId = json[1] as string;
-    const message = json[2] as string;
+    const message = typeof json[2] === 'string' ? json[2] : 'no reason provided';
 
     const relay = this.relays.get(relayUrl);
     if (relay) {

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -1320,20 +1320,28 @@ export class NostrClient {
             finishWith(pickWinner(), id);
           }
         },
-        // CLOSED frame from the relay (rate-limit, auth-required,
-        // etc.) is terminal for this sub *on the sending relay*. Same
-        // logic: only settle when all connected relays have either
-        // EOSE'd or CLOSED'd. handleClosedMessage records the
-        // rejection on the sending relay's closedSubIds before
-        // calling onError, so we can inspect that state here.
+        // Subscription error from the SDK — fires from three paths
+        // that all need the same "is it time to settle?" check:
+        //   1. Relay sent CLOSED for this sub. In a multi-relay
+        //      client the same sub_id may still be alive on a
+        //      healthy relay; settling on the first CLOSED would
+        //      prematurely abort a query other relays could
+        //      satisfy. handleClosedMessage records the rejection
+        //      on the sending relay's closedSubIds before invoking
+        //      us, so we can decide via allRelaysDoneFor.
+        //   2. Relay disconnected mid-query (socket.onclose →
+        //      synthetic onError). The relay no longer counts as
+        //      connected, so allRelaysDoneFor excludes it.
+        //   3. Client disconnected (disconnect() → synthetic
+        //      onError). All relays are torn down, allRelaysDoneFor
+        //      sees zero connected and settles.
         onError: (id, message) => {
-          console.warn(`Relay closed subscription ${id}: ${message}`);
+          console.warn(`Subscription error on ${id}: ${message}`);
           if (allRelaysDone(id)) {
             finishWith(pickWinner(), id);
           }
           // else: keep waiting for EOSE / CLOSED from remaining
-          // relays or the overall query timeout — no single relay
-          // can stop the world for others.
+          // relays or the overall query timeout.
         },
       });
     });

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -105,6 +105,11 @@ interface RelayConnection {
   lastPongTime: number;
   unansweredPings: number;
   wasConnected: boolean;  // Track if this relay was previously connected (for reconnect vs initial connect)
+  // Sub_ids this specific relay has CLOSED for us. Used to skip them in
+  // resubscribeAll / post-AUTH resubscribe so we don't loop on a
+  // rejected REQ. Per-relay (not global) because multi-relay clients
+  // may have the same sub_id alive on a different healthy relay.
+  closedSubIds: Set<string>;
 }
 
 /**
@@ -275,6 +280,10 @@ export class NostrClient {
             lastPongTime: Date.now(),
             unansweredPings: 0,
             wasConnected: existingRelay?.wasConnected ?? false,
+            // Reset on every new connection: a relay's per-connection
+            // sub-slot accounting is fresh, so previously-rejected REQs
+            // should be re-issued on the new socket.
+            closedSubIds: new Set<string>(),
           };
 
           socket.onopen = () => {
@@ -480,6 +489,10 @@ export class NostrClient {
     if (!relay?.socket || !relay.connected) return;
 
     for (const [subId, info] of this.subscriptions) {
+      // Skip subs this relay has previously CLOSED — re-issuing them
+      // just triggers the same rejection in a loop. Other healthy
+      // relays still resubscribe.
+      if (relay.closedSubIds.has(subId)) continue;
       const message = JSON.stringify(['REQ', subId, info.filter.toJSON()]);
       relay.socket.send(message);
     }
@@ -502,7 +515,7 @@ export class NostrClient {
   /**
    * Handle a message from a relay.
    */
-  private handleRelayMessage(_url: string, message: string): void {
+  private handleRelayMessage(relayUrl: string, message: string): void {
     try {
       const json = JSON.parse(message) as unknown[];
       if (!Array.isArray(json) || json.length < 2) return;
@@ -523,10 +536,10 @@ export class NostrClient {
           this.handleNoticeMessage(json);
           break;
         case 'CLOSED':
-          this.handleClosedMessage(json);
+          this.handleClosedMessage(relayUrl, json);
           break;
         case 'AUTH':
-          this.handleAuthMessage(_url, json);
+          this.handleAuthMessage(relayUrl, json);
           break;
       }
     } catch {
@@ -603,27 +616,32 @@ export class NostrClient {
   /**
    * Handle CLOSED message from relay (subscription closed by relay).
    *
-   * NIP-01 CLOSED frames are terminal for the named subscription on the
-   * relay side. We must remove the entry from `this.subscriptions`
-   * immediately, otherwise:
-   *   - `resubscribeAll` (on reconnect) re-issues the REQ, triggering the
-   *     same rejection loop;
-   *   - `handleAuthMessage` post-AUTH resubscribe does the same;
-   *   - the entry leaks forever, and the caller silently waits for events
-   *     that will never arrive (typically misdiagnosed as "no data found"
-   *     after the query timeout fires).
+   * NIP-01 CLOSED frames are terminal for the named subscription **on
+   * the sending relay**. In a multi-relay client the same sub_id may
+   * still be alive on a healthy relay, so we must NOT delete the
+   * global `this.subscriptions` entry here — that would silently drop
+   * EVENT/EOSE frames from the still-healthy relays in
+   * `handleEventMessage` (which consults the global map).
+   *
+   * Instead we record the rejection on the sending relay's
+   * `closedSubIds` set so `resubscribeAll` and post-AUTH resubscribe
+   * skip it on this relay only. The listener is notified via
+   * `onError` so callers (e.g. queryWithFirstSeenWins) can decide to
+   * settle and explicitly `unsubscribe()` if they want to give up
+   * across all relays.
    */
-  private handleClosedMessage(json: unknown[]): void {
+  private handleClosedMessage(relayUrl: string, json: unknown[]): void {
     if (json.length < 3) return;
 
     const subscriptionId = json[1] as string;
     const message = json[2] as string;
 
-    const subscription = this.subscriptions.get(subscriptionId);
-    // Remove from the local map BEFORE notifying the listener so that any
-    // listener-driven follow-up (e.g. retry) starts from a clean slate.
-    this.subscriptions.delete(subscriptionId);
+    const relay = this.relays.get(relayUrl);
+    if (relay) {
+      relay.closedSubIds.add(subscriptionId);
+    }
 
+    const subscription = this.subscriptions.get(subscriptionId);
     if (subscription?.listener.onError) {
       subscription.listener.onError(subscriptionId, `Subscription closed: ${message}`);
     }
@@ -1025,12 +1043,18 @@ export class NostrClient {
 
     this.subscriptions.delete(subscriptionId);
 
-    // Send CLOSE to all connected relays
+    // Send CLOSE to all connected relays — except those that already
+    // CLOSED the sub themselves (no point telling the relay something
+    // it told us).
     const message = JSON.stringify(['CLOSE', subscriptionId]);
     for (const [, relay] of this.relays) {
-      if (relay.connected && relay.socket?.readyState === OPEN) {
+      if (relay.connected && relay.socket?.readyState === OPEN
+          && !relay.closedSubIds.has(subscriptionId)) {
         relay.socket.send(message);
       }
+      // Either way, drop the per-relay closed marker now that the
+      // sub is gone from the global map.
+      relay.closedSubIds.delete(subscriptionId);
     }
   }
 

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -110,6 +110,12 @@ interface RelayConnection {
   // rejected REQ. Per-relay (not global) because multi-relay clients
   // may have the same sub_id alive on a different healthy relay.
   closedSubIds: Set<string>;
+  // Sub_ids this specific relay has EOSE'd for us. Combined with
+  // closedSubIds, lets queryWithFirstSeenWins decide when ALL
+  // connected relays have finished (either streamed EOSE or rejected
+  // with CLOSED) so it doesn't settle early off a single fast relay
+  // while a slower one still has matching events to deliver.
+  eosedSubIds: Set<string>;
 }
 
 /**
@@ -294,6 +300,7 @@ export class NostrClient {
             // sub-slot accounting is fresh, so previously-rejected REQs
             // should be re-issued on the new socket.
             closedSubIds: new Set<string>(),
+            eosedSubIds: new Set<string>(),
           };
 
           socket.onopen = () => {
@@ -540,7 +547,7 @@ export class NostrClient {
           this.handleOkMessage(json);
           break;
         case 'EOSE':
-          this.handleEOSEMessage(json);
+          this.handleEOSEMessage(relayUrl, json);
           break;
         case 'NOTICE':
           this.handleNoticeMessage(json);
@@ -602,13 +609,25 @@ export class NostrClient {
 
   /**
    * Handle EOSE (End of Stored Events) message from relay.
+   *
+   * Records the per-relay EOSE marker (mirroring closedSubIds) so
+   * queryWithFirstSeenWins can decide when ALL connected relays have
+   * finished — either streamed EOSE or rejected with CLOSED — instead
+   * of settling off the first fast relay's EOSE while a slower relay
+   * is still about to deliver matching events.
    */
-  private handleEOSEMessage(json: unknown[]): void {
-    if (json.length < 2) return;
+  private handleEOSEMessage(relayUrl: string, json: unknown[]): void {
+    if (json.length < 2 || typeof json[1] !== 'string') return;
 
-    const subscriptionId = json[1] as string;
+    const subscriptionId = json[1];
+    if (!this.subscriptions.has(subscriptionId)) return;
+
+    const relay = this.relays.get(relayUrl);
+    if (relay) {
+      relay.eosedSubIds.add(subscriptionId);
+    }
+
     const subscription = this.subscriptions.get(subscriptionId);
-
     if (subscription?.listener.onEndOfStoredEvents) {
       subscription.listener.onEndOfStoredEvents(subscriptionId);
     }
@@ -1055,6 +1074,16 @@ export class NostrClient {
 
     this.subscriptions.set(subscriptionId, { filter, listener });
 
+    // Wipe any stale per-relay EOSE/CLOSED markers for this sub_id
+    // before issuing the REQ — otherwise a fresh subscribe with a
+    // sub_id that was previously CLOSED (or was just freshly
+    // EOSE'd) would be skipped or treated as "already done" on
+    // those relays.
+    for (const [, relay] of this.relays) {
+      relay.closedSubIds.delete(subscriptionId);
+      relay.eosedSubIds.delete(subscriptionId);
+    }
+
     // Send subscription request to all connected relays
     const message = JSON.stringify(['REQ', subscriptionId, filter.toJSON()]);
     for (const [, relay] of this.relays) {
@@ -1084,9 +1113,10 @@ export class NostrClient {
           && !relay.closedSubIds.has(subscriptionId)) {
         relay.socket.send(message);
       }
-      // Either way, drop the per-relay closed marker now that the
-      // sub is gone from the global map.
+      // Drop both per-relay markers now that the sub is gone from
+      // the global map.
       relay.closedSubIds.delete(subscriptionId);
+      relay.eosedSubIds.delete(subscriptionId);
     }
   }
 
@@ -1117,6 +1147,11 @@ export class NostrClient {
     return new Promise((resolve) => {
       let subscriptionId = '';
       let settled = false;
+      // Declared as `let` and initialized lazily so `finishWith` can be
+      // invoked before the setTimeout call below without hitting the
+      // TDZ on `clearTimeout(timeoutId)`. (The same comment on the
+      // listener anticipates synchronous-callback hypothetical paths.)
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
       // Accept an explicit `id` so callers from inside the listener can
       // pass the sub_id the relay echoed back. This guards against any
@@ -1127,15 +1162,17 @@ export class NostrClient {
       const finishWith = (result: T | null, id?: string) => {
         if (settled) return;
         settled = true;
-        clearTimeout(timeoutId);
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
         const subId = id || subscriptionId;
         if (subId) this.unsubscribe(subId);
         resolve(result);
       };
 
-      const timeoutId = setTimeout(() => finishWith(null), this.queryTimeoutMs);
+      timeoutId = setTimeout(() => finishWith(null), this.queryTimeoutMs);
 
       const authors = new Map<string, { firstSeen: number; latestEvent: Event }>();
+
+      const allRelaysDone = (id: string): boolean => this.allRelaysDoneFor(id);
 
       const pickWinner = (): T | null => {
         let winnerEntry: { firstSeen: number; latestEvent: Event } | null = null;
@@ -1168,32 +1205,48 @@ export class NostrClient {
             }
           }
         },
-        onEndOfStoredEvents: (id) => finishWith(pickWinner(), id),
-        // CLOSED frame from the relay (rate-limit, auth-required, etc.)
-        // is terminal for this sub *on the sending relay*. In a
-        // multi-relay client the same sub_id may still be alive on a
-        // healthy relay, so we must NOT settle on the first CLOSED —
-        // that would prematurely abort a query other relays could
-        // satisfy. Settle only when ALL connected relays have closed
-        // this sub (no chance of an EOSE-with-data anywhere).
-        // handleClosedMessage records the rejection on the sending
-        // relay's closedSubIds before calling onError, so by the time
-        // we get here we can decide by inspecting that state across
-        // all connected relays.
-        onError: (id, message) => {
-          console.warn(`Relay closed subscription ${id}: ${message}`);
-          const allClosed = Array.from(this.relays.values())
-            .filter((r) => r.connected)
-            .every((r) => r.closedSubIds.has(id));
-          if (allClosed) {
+        // EOSE means *this relay* has finished delivering stored
+        // events. In a multi-relay client we must not settle yet — a
+        // slower relay may still be about to deliver matching events.
+        // Settle only when every connected relay has either EOSE'd
+        // OR CLOSED'd this sub. (Single-relay clients are unaffected:
+        // allDone is trivially true with one relay.)
+        onEndOfStoredEvents: (id) => {
+          if (allRelaysDone(id)) {
             finishWith(pickWinner(), id);
           }
-          // else: keep waiting for EOSE from a healthy relay or the
-          // overall query timeout — no relay can stop the world for
-          // others.
+        },
+        // CLOSED frame from the relay (rate-limit, auth-required,
+        // etc.) is terminal for this sub *on the sending relay*. Same
+        // logic: only settle when all connected relays have either
+        // EOSE'd or CLOSED'd. handleClosedMessage records the
+        // rejection on the sending relay's closedSubIds before
+        // calling onError, so we can inspect that state here.
+        onError: (id, message) => {
+          console.warn(`Relay closed subscription ${id}: ${message}`);
+          if (allRelaysDone(id)) {
+            finishWith(pickWinner(), id);
+          }
+          // else: keep waiting for EOSE / CLOSED from remaining
+          // relays or the overall query timeout — no single relay
+          // can stop the world for others.
         },
       });
     });
+  }
+
+  /**
+   * True if every currently-connected relay has finished delivering
+   * for the given sub_id (either EOSE'd or CLOSED'd it). Used by
+   * queryWithFirstSeenWins to coordinate multi-relay settlement.
+   */
+  private allRelaysDoneFor(subscriptionId: string): boolean {
+    const connected = Array.from(this.relays.values()).filter((r) => r.connected);
+    // No connected relays at all → nothing to wait for; settle.
+    if (connected.length === 0) return true;
+    return connected.every(
+      (r) => r.eosedSubIds.has(subscriptionId) || r.closedSubIds.has(subscriptionId),
+    );
   }
 
   /**

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -279,12 +279,25 @@ export class NostrClient {
     }
 
     return new Promise((resolve, reject) => {
+      // `timedOut` is observed inside the createWebSocket .then below.
+      // Without it, a slow socket creation that resolves AFTER we've
+      // already rejected the outer promise would still register the
+      // socket in this.relays and start a pingTimer — orphan
+      // resources the caller can't see or clean up.
+      let timedOut = false;
       const timeoutId = setTimeout(() => {
+        timedOut = true;
         reject(new Error(`Connection to ${url} timed out`));
       }, CONNECTION_TIMEOUT_MS);
 
       createWebSocket(url)
         .then((socket) => {
+          if (timedOut) {
+            // Caller already saw the rejection. Discard the late
+            // socket so we don't leak it.
+            try { socket.close(1000, 'Connection setup timed out'); } catch { /* ignore */ }
+            return;
+          }
           const relay: RelayConnection = {
             url,
             socket,
@@ -568,9 +581,9 @@ export class NostrClient {
    * Handle EVENT message from relay.
    */
   private handleEventMessage(json: unknown[]): void {
-    if (json.length < 3) return;
+    if (json.length < 3 || typeof json[1] !== 'string') return;
 
-    const subscriptionId = json[1] as string;
+    const subscriptionId = json[1];
     const eventData = json[2];
 
     const subscription = this.subscriptions.get(subscriptionId);
@@ -721,9 +734,20 @@ export class NostrClient {
     // marker for this relay before resubscribeAll runs. Permanent
     // rejections (max_subscriptions, etc.) will simply be re-rejected
     // and re-recorded; transient auth-required ones now succeed.
+    //
+    // We also clear `eosedSubIds`: a relay may have EOSE'd a pre-auth
+    // sub (returning zero stored events because the filter wasn't
+    // satisfiable without auth context). Post-auth that's no longer
+    // true, and we MUST re-arm the local "still waiting" state for
+    // any in-flight queryWithFirstSeenWins — otherwise allRelaysDoneFor
+    // would see this relay as already-done from the stale marker and
+    // settle prematurely.
     setTimeout(() => {
       const r = this.relays.get(relayUrl);
-      if (r) r.closedSubIds.clear();
+      if (r) {
+        r.closedSubIds.clear();
+        r.eosedSubIds.clear();
+      }
       this.resubscribeAll(relayUrl);
     }, AUTH_RESUBSCRIBE_DELAY_MS);
   }
@@ -747,24 +771,41 @@ export class NostrClient {
     }
     this.eventQueue = [];
 
-    // Close all relay connections and clean up timers
+    // Close all relay connections and clean up timers. Mark every
+    // relay disconnected synchronously BEFORE we notify subscriptions
+    // below, so any listener that consults `allRelaysDoneFor` sees
+    // zero connected relays and settles immediately.
     for (const [url, relay] of this.relays) {
-      // Stop ping timer
+      relay.connected = false;
       if (relay.pingTimer) {
         clearInterval(relay.pingTimer);
         relay.pingTimer = null;
       }
-      // Stop reconnect timer
       if (relay.reconnectTimer) {
         clearTimeout(relay.reconnectTimer);
         relay.reconnectTimer = null;
       }
-      // Close socket
       if (relay.socket && relay.socket.readyState !== CLOSED) {
         relay.socket.close(1000, 'Client disconnected');
       }
       this.emitConnectionEvent('disconnect', url, 'Client disconnected');
     }
+
+    // Notify in-flight subscriptions that we're shutting down.
+    // queryWithFirstSeenWins.onError re-checks allRelaysDoneFor (now
+    // 0 connected → trivially true) and settles immediately, sparing
+    // callers the full queryTimeoutMs wait. Snapshot keys first
+    // because the listener may call unsubscribe(), which mutates
+    // this.subscriptions while we iterate.
+    const inflightSubs = Array.from(this.subscriptions.entries());
+    for (const [subId, sub] of inflightSubs) {
+      try {
+        sub.listener.onError?.(subId, 'Client disconnected');
+      } catch {
+        // Ignore listener errors — we're tearing down anyway.
+      }
+    }
+
     this.relays.clear();
     this.subscriptions.clear();
   }

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -153,6 +153,22 @@ export class NostrClient {
   }
 
   /**
+   * Replace the key manager used for signing and encryption.
+   * The connection stays alive — only future AUTH responses and published events use the new key.
+   * @param keyManager New key manager
+   */
+  setKeyManager(keyManager: NostrKeyManager): void {
+    this.keyManager = keyManager;
+  }
+
+  /**
+   * Get the current key manager.
+   */
+  getKeyManager(): NostrKeyManager {
+    return this.keyManager;
+  }
+
+  /**
    * Add a connection event listener.
    * @param listener Listener for connection events
    */
@@ -199,14 +215,6 @@ export class NostrClient {
         // Ignore listener errors
       }
     }
-  }
-
-  /**
-   * Get the key manager.
-   * @returns The key manager instance
-   */
-  getKeyManager(): NostrKeyManager {
-    return this.keyManager;
   }
 
   /**
@@ -419,16 +427,25 @@ export class NostrClient {
         return;
       }
 
-      // Send a subscription request as a ping (relays respond with EOSE)
-      // Use a single fixed subscription ID per relay to avoid accumulating subscriptions
-      // Note: limit:1 is used because some relays don't respond to limit:0
+      // Send a subscription request as a ping (relays respond with EOSE).
+      // The filter MUST be tightly scoped — an open `{ limit: 1 }` filter
+      // with no kinds/authors/#p will, after EOSE, stream every event the
+      // relay receives (NIP-01 live tail), saturating the connection and
+      // exhausting per-connection subscription slots on busy relays.
+      // Scoping by `authors:[self]` keeps the live tail empty in practice
+      // (the relay would only forward our own future events).
       try {
         const pingSubId = `ping`;
+        const selfPubkey = this.keyManager.getPublicKeyHex();
         // First close any existing ping subscription to ensure we don't accumulate
         const closeMessage = JSON.stringify(['CLOSE', pingSubId]);
         relay.socket.send(closeMessage);
         // Then send the new ping request (limit:1 ensures relay sends EOSE)
-        const pingMessage = JSON.stringify(['REQ', pingSubId, { limit: 1 }]);
+        const pingMessage = JSON.stringify([
+          'REQ',
+          pingSubId,
+          { authors: [selfPubkey], limit: 1 },
+        ]);
         relay.socket.send(pingMessage);
         relay.unansweredPings++;
       } catch {
@@ -585,6 +602,16 @@ export class NostrClient {
 
   /**
    * Handle CLOSED message from relay (subscription closed by relay).
+   *
+   * NIP-01 CLOSED frames are terminal for the named subscription on the
+   * relay side. We must remove the entry from `this.subscriptions`
+   * immediately, otherwise:
+   *   - `resubscribeAll` (on reconnect) re-issues the REQ, triggering the
+   *     same rejection loop;
+   *   - `handleAuthMessage` post-AUTH resubscribe does the same;
+   *   - the entry leaks forever, and the caller silently waits for events
+   *     that will never arrive (typically misdiagnosed as "no data found"
+   *     after the query timeout fires).
    */
   private handleClosedMessage(json: unknown[]): void {
     if (json.length < 3) return;
@@ -593,6 +620,10 @@ export class NostrClient {
     const message = json[2] as string;
 
     const subscription = this.subscriptions.get(subscriptionId);
+    // Remove from the local map BEFORE notifying the listener so that any
+    // listener-driven follow-up (e.g. retry) starts from a clean slate.
+    this.subscriptions.delete(subscriptionId);
+
     if (subscription?.listener.onError) {
       subscription.listener.onError(subscriptionId, `Subscription closed: ${message}`);
     }
@@ -1029,13 +1060,33 @@ export class NostrClient {
   ): Promise<T | null> {
     return new Promise((resolve) => {
       let subscriptionId = '';
+      let settled = false;
 
-      const timeoutId = setTimeout(() => {
+      const finishWith = (result: T | null) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
         if (subscriptionId) this.unsubscribe(subscriptionId);
-        resolve(null);
-      }, this.queryTimeoutMs);
+        resolve(result);
+      };
+
+      const timeoutId = setTimeout(() => finishWith(null), this.queryTimeoutMs);
 
       const authors = new Map<string, { firstSeen: number; latestEvent: Event }>();
+
+      const pickWinner = (): T | null => {
+        let winnerEntry: { firstSeen: number; latestEvent: Event } | null = null;
+        let winnerPubkey = '';
+        for (const [pubkey, entry] of authors) {
+          if (!winnerEntry
+              || entry.firstSeen < winnerEntry.firstSeen
+              || (entry.firstSeen === winnerEntry.firstSeen && pubkey < winnerPubkey)) {
+            winnerEntry = entry;
+            winnerPubkey = pubkey;
+          }
+        }
+        return winnerEntry ? extractResult(winnerEntry.latestEvent) : null;
+      };
 
       subscriptionId = this.subscribe(filter, {
         onEvent: (event) => {
@@ -1054,22 +1105,14 @@ export class NostrClient {
             }
           }
         },
-        onEndOfStoredEvents: () => {
-          clearTimeout(timeoutId);
-          this.unsubscribe(subscriptionId);
-
-          let winnerEntry: { firstSeen: number; latestEvent: Event } | null = null;
-          let winnerPubkey = '';
-          for (const [pubkey, entry] of authors) {
-            if (!winnerEntry
-                || entry.firstSeen < winnerEntry.firstSeen
-                || (entry.firstSeen === winnerEntry.firstSeen && pubkey < winnerPubkey)) {
-              winnerEntry = entry;
-              winnerPubkey = pubkey;
-            }
-          }
-
-          resolve(winnerEntry ? extractResult(winnerEntry.latestEvent) : null);
+        onEndOfStoredEvents: () => finishWith(pickWinner()),
+        // CLOSED frame from the relay (rate-limit, auth-required, etc.) is
+        // terminal for this subscription. Settle promptly with whatever we
+        // collected so far instead of waiting for the timeout. Without this
+        // a relay-side rejection looks identical to "no data exists".
+        onError: (_subId, message) => {
+          console.warn(`Relay closed subscription ${_subId}: ${message}`);
+          finishWith(pickWinner());
         },
       });
     });

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -737,18 +737,19 @@ export class NostrClient {
     // NIP-42 transient case: relays that require AUTH typically reject
     // pre-auth REQs with `CLOSED("auth-required:...")` and then send
     // an AUTH challenge. resubscribeAfterAuth re-issues the sub, so
-    // this rejection is NOT terminal. If we marked closedSubIds here:
-    //   1. queryWithFirstSeenWins.onError → allRelaysDoneFor → true
-    //      (single-relay case) → settles null + unsubscribes → the
-    //      sub is gone from the global Map by the time
-    //      resubscribeAfterAuth runs → no retry, query lost.
-    //   2. resubscribeAll on AUTH-success would skip this sub for
-    //      the brief window before resubscribeAfterAuth clears the
-    //      marker (hardened by the clear, but skip-then-clear is
-    //      fragile).
+    // this rejection is NOT terminal. If we marked closedSubIds here,
+    // queryWithFirstSeenWins.onError would settle the future
+    // prematurely (single-relay → allRelaysDoneFor=true), unsubscribe
+    // the sub, and the post-AUTH retry would find nothing to retry.
     // Listener still gets onError so callers see the reason; we just
     // don't poison the per-relay state with a transient marker.
-    const isAuthRequired = message.startsWith('auth-required:')
+    //
+    // We accept three on-the-wire shapes: `auth-required:...`
+    // (NIP-42 standard with reason), `auth-required ...` (whitespace
+    // separator), and bare `auth-required` (no suffix at all — some
+    // relays / tests).
+    const isAuthRequired = message === 'auth-required'
+        || message.startsWith('auth-required:')
         || message.startsWith('auth-required ');
 
     const relay = this.relays.get(relayUrl);
@@ -790,27 +791,26 @@ export class NostrClient {
     const message = JSON.stringify(['AUTH', authEvent.toJSON()]);
     relay.socket.send(message);
 
-    // Re-send subscriptions after auth (relay may have ignored pre-auth requests).
-    // Some relays respond to pre-auth REQs with `["CLOSED","<sub>","auth-required:..."]`,
-    // which lands in `relay.closedSubIds`. Once we've responded to the
-    // AUTH challenge, those subs are eligible for retry — so clear the
-    // marker for this relay before resubscribeAll runs. Permanent
-    // rejections (max_subscriptions, etc.) will simply be re-rejected
-    // and re-recorded; transient auth-required ones now succeed.
+    // Re-send subscriptions after auth (relay may have ignored pre-auth
+    // requests). Two separate per-relay markers, two separate decisions:
     //
-    // We also clear `eosedSubIds`: a relay may have EOSE'd a pre-auth
-    // sub (returning zero stored events because the filter wasn't
-    // satisfiable without auth context). Post-auth that's no longer
-    // true, and we MUST re-arm the local "still waiting" state for
-    // any in-flight queryWithFirstSeenWins — otherwise allRelaysDoneFor
-    // would see this relay as already-done from the stale marker and
-    // settle prematurely.
+    //  - `closedSubIds`: do NOT clear. handleClosedMessage already
+    //    skips the auth-required transient case, so anything in this
+    //    set is a TERMINAL rejection (rate-limited, blocked, etc.)
+    //    that AUTH does not relax. The resubscribeAll guard then
+    //    correctly skips terminal-rejected subs on this relay. They
+    //    will be retried on the next reconnect, when onopen creates a
+    //    fresh RelayConnection with empty markers.
+    //
+    //  - `eosedSubIds`: clear. A relay may have EOSE'd a pre-auth sub
+    //    with zero events (filter unsatisfiable without auth context);
+    //    post-auth the same filter might match. We must re-arm the
+    //    local "still waiting" state so any in-flight
+    //    queryWithFirstSeenWins doesn't see this relay as already-done
+    //    from a stale marker.
     setTimeout(() => {
       const r = this.relays.get(relayUrl);
-      if (r) {
-        r.closedSubIds.clear();
-        r.eosedSubIds.clear();
-      }
+      if (r) r.eosedSubIds.clear();
       this.resubscribeAll(relayUrl);
     }, AUTH_RESUBSCRIBE_DELAY_MS);
   }

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -159,7 +159,17 @@ export class NostrClient {
 
   /**
    * Replace the key manager used for signing and encryption.
-   * The connection stays alive — only future AUTH responses and published events use the new key.
+   *
+   * The connection stays alive — but every operation that consults the
+   * key manager from this point on uses the new key, including:
+   *   - signing future published events,
+   *   - signing NIP-42 AUTH challenge responses,
+   *   - the `authors:[selfPubkey]` filter on the keepalive ping REQ
+   *     (computed each ping interval),
+   *   - any other code path that calls `getPublicKeyHex()` on the
+   *     stored manager.
+   *
+   * Existing in-flight subscriptions are not re-issued or re-keyed.
    * @param keyManager New key manager
    */
   setKeyManager(keyManager: NostrKeyManager): void {
@@ -671,8 +681,16 @@ export class NostrClient {
     const message = JSON.stringify(['AUTH', authEvent.toJSON()]);
     relay.socket.send(message);
 
-    // Re-send subscriptions after auth (relay may have ignored pre-auth requests)
+    // Re-send subscriptions after auth (relay may have ignored pre-auth requests).
+    // Some relays respond to pre-auth REQs with `["CLOSED","<sub>","auth-required:..."]`,
+    // which lands in `relay.closedSubIds`. Once we've responded to the
+    // AUTH challenge, those subs are eligible for retry — so clear the
+    // marker for this relay before resubscribeAll runs. Permanent
+    // rejections (max_subscriptions, etc.) will simply be re-rejected
+    // and re-recorded; transient auth-required ones now succeed.
     setTimeout(() => {
+      const r = this.relays.get(relayUrl);
+      if (r) r.closedSubIds.clear();
       this.resubscribeAll(relayUrl);
     }, AUTH_RESUBSCRIBE_DELAY_MS);
   }

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -1062,11 +1062,18 @@ export class NostrClient {
       let subscriptionId = '';
       let settled = false;
 
-      const finishWith = (result: T | null) => {
+      // Accept an explicit `id` so callers from inside the listener can
+      // pass the sub_id the relay echoed back. This guards against any
+      // future change to subscribe() that would invoke listener
+      // callbacks before its return value is bound to `subscriptionId`
+      // — the closure-captured value would still be `''` and we'd skip
+      // the CLOSE frame, leaking the slot on the relay.
+      const finishWith = (result: T | null, id?: string) => {
         if (settled) return;
         settled = true;
         clearTimeout(timeoutId);
-        if (subscriptionId) this.unsubscribe(subscriptionId);
+        const subId = id || subscriptionId;
+        if (subId) this.unsubscribe(subId);
         resolve(result);
       };
 
@@ -1105,14 +1112,14 @@ export class NostrClient {
             }
           }
         },
-        onEndOfStoredEvents: () => finishWith(pickWinner()),
+        onEndOfStoredEvents: (id) => finishWith(pickWinner(), id),
         // CLOSED frame from the relay (rate-limit, auth-required, etc.) is
         // terminal for this subscription. Settle promptly with whatever we
         // collected so far instead of waiting for the timeout. Without this
         // a relay-side rejection looks identical to "no data exists".
-        onError: (_subId, message) => {
-          console.warn(`Relay closed subscription ${_subId}: ${message}`);
-          finishWith(pickWinner());
+        onError: (id, message) => {
+          console.warn(`Relay closed subscription ${id}: ${message}`);
+          finishWith(pickWinner(), id);
         },
       });
     });

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -47,6 +47,26 @@ const DEFAULT_PING_INTERVAL_MS = 30000;
 const PING_SUB_ID = '__nostr-sdk-keepalive__';
 
 /**
+ * Filter id used by the keepalive REQ. We need a filter the relay can
+ * resolve immediately (so EOSE comes back fast = relay is alive), but
+ * which can NOT match any real event past EOSE (so the live tail stays
+ * empty).
+ *
+ * Scoping by `authors:[selfPubkey]` was the original approach but it
+ * matched every event the wallet itself published — including kind-31113
+ * token transfers — which the relay then echoed back on the keepalive
+ * sub. Some relays dedupe events across overlapping subs, so the
+ * wallet's own consumer subscription would not receive its own echo and
+ * any flow waiting on that echo would time out.
+ *
+ * The filter `{ ids: ['00...00'] }` asks the relay for a single event
+ * whose id is exactly the all-zero hash. Real Nostr event ids are
+ * SHA-256 over a canonical JSON serialization, so the all-zero hash is
+ * unreachable in practice. Result: instant EOSE, empty live tail.
+ */
+const KEEPALIVE_NEVER_MATCH_ID = '0'.repeat(64);
+
+/**
  * Delay before resubscribing after NIP-42 authentication.
  * This gives the relay time to process the AUTH response before we send
  * subscription requests. Without this delay, some relays may still reject
@@ -539,14 +559,21 @@ export class NostrClient {
       }
 
       // Send a subscription request as a ping (relays respond with EOSE).
-      // The filter MUST be tightly scoped — an open `{ limit: 1 }` filter
-      // with no kinds/authors/#p will, after EOSE, stream every event the
-      // relay receives (NIP-01 live tail), saturating the connection and
-      // exhausting per-connection subscription slots on busy relays.
-      // Scoping by `authors:[self]` keeps the live tail empty in practice
-      // (the relay would only forward our own future events).
+      // The filter MUST be tightly scoped to something no real event can
+      // match — both for the initial query AND the post-EOSE live tail.
+      //
+      // Earlier iterations used `authors:[self]` reasoning that "the
+      // relay would only forward our own future events". That reasoning
+      // was wrong: it precisely DOES forward every event the wallet
+      // publishes, including kind-31113 token transfers. Some relays
+      // dedupe events across overlapping subs, so the wallet's own
+      // consumer subscription would miss its echo and any flow waiting
+      // on it would time out.
+      //
+      // {@link KEEPALIVE_NEVER_MATCH_ID} (the all-zero SHA-256 hash) is
+      // unreachable in real event-id space, so the relay returns EOSE
+      // immediately and the live tail never matches.
       try {
-        const selfPubkey = this.keyManager.getPublicKeyHex();
         // First close any existing ping subscription to ensure we don't accumulate
         const closeMessage = JSON.stringify(['CLOSE', PING_SUB_ID]);
         relay.socket.send(closeMessage);
@@ -554,7 +581,7 @@ export class NostrClient {
         const pingMessage = JSON.stringify([
           'REQ',
           PING_SUB_ID,
-          { authors: [selfPubkey], limit: 1 },
+          { ids: [KEEPALIVE_NEVER_MATCH_ID], limit: 1 },
         ]);
         relay.socket.send(pingMessage);
         relay.unansweredPings++;

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -36,6 +36,17 @@ const DEFAULT_MAX_RECONNECT_INTERVAL_MS = 30000;
 const DEFAULT_PING_INTERVAL_MS = 30000;
 
 /**
+ * Internal sub_id reserved for the keepalive REQ. Namespaced with a
+ * `__nostr-sdk-` prefix so that user code calling
+ * {@link NostrClient.subscribe} with an explicit `subscriptionId`
+ * cannot collide — a user choosing the literal `"ping"` would
+ * otherwise have their subscription forcibly CLOSE/REQ'd every
+ * ping interval. The leading `__` is a stable convention for
+ * "do not pick this name."
+ */
+const PING_SUB_ID = '__nostr-sdk-keepalive__';
+
+/**
  * Delay before resubscribing after NIP-42 authentication.
  * This gives the relay time to process the AUTH response before we send
  * subscription requests. Without this delay, some relays may still reject
@@ -520,15 +531,14 @@ export class NostrClient {
       // Scoping by `authors:[self]` keeps the live tail empty in practice
       // (the relay would only forward our own future events).
       try {
-        const pingSubId = `ping`;
         const selfPubkey = this.keyManager.getPublicKeyHex();
         // First close any existing ping subscription to ensure we don't accumulate
-        const closeMessage = JSON.stringify(['CLOSE', pingSubId]);
+        const closeMessage = JSON.stringify(['CLOSE', PING_SUB_ID]);
         relay.socket.send(closeMessage);
         // Then send the new ping request (limit:1 ensures relay sends EOSE)
         const pingMessage = JSON.stringify([
           'REQ',
-          pingSubId,
+          PING_SUB_ID,
           { authors: [selfPubkey], limit: 1 },
         ]);
         relay.socket.send(pingMessage);

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -397,6 +397,19 @@ export class NostrClient {
             relay.connected = false;
             this.stopPingTimer(url);
 
+            // Pre-onopen close: TCP handshake failure or relay
+            // immediately closed the WS during the upgrade. Without
+            // this, the connectToRelay promise stays pending until
+            // CONNECTION_TIMEOUT_MS (30s) expires; surfacing it now
+            // lets the caller see the failure promptly and retry.
+            if (!wasConnected && !timedOut) {
+              timedOut = true;
+              clearTimeout(timeoutId);
+              reject(new Error(
+                `Connection to ${url} closed during handshake: ${event?.reason || 'no reason'}`,
+              ));
+            }
+
             if (wasConnected) {
               const reason = event?.reason || 'Connection closed';
               this.emitConnectionEvent('disconnect', url, reason);

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -645,9 +645,15 @@ export class NostrClient {
     // valid. Dropping such frames was exactly the leak this PR sets out
     // to fix — no closedSubIds marker and no onError notification means
     // queries hang until timeout and resubscribe loops persist.
-    if (json.length < 2) return;
+    if (json.length < 2 || typeof json[1] !== 'string') return;
 
-    const subscriptionId = json[1] as string;
+    const subscriptionId = json[1];
+    // Ignore CLOSED for sub_ids we don't know about. A misbehaving or
+    // malicious relay could otherwise spam us with arbitrary sub_ids
+    // and grow `closedSubIds` unbounded over a long-lived connection,
+    // and could pre-emptively block sub_ids we might use later.
+    if (!this.subscriptions.has(subscriptionId)) return;
+
     const message = typeof json[2] === 'string' ? json[2] : 'no reason provided';
 
     const relay = this.relays.get(relayUrl);
@@ -657,7 +663,11 @@ export class NostrClient {
 
     const subscription = this.subscriptions.get(subscriptionId);
     if (subscription?.listener.onError) {
-      subscription.listener.onError(subscriptionId, `Subscription closed: ${message}`);
+      // Pass the relay's reason through verbatim so callers can
+      // pattern-match on standard prefixes (`auth-required:`,
+      // `rate-limited:`, `blocked:`, etc.) without parsing through
+      // a wrapper string.
+      subscription.listener.onError(subscriptionId, message);
     }
   }
 
@@ -1159,13 +1169,28 @@ export class NostrClient {
           }
         },
         onEndOfStoredEvents: (id) => finishWith(pickWinner(), id),
-        // CLOSED frame from the relay (rate-limit, auth-required, etc.) is
-        // terminal for this subscription. Settle promptly with whatever we
-        // collected so far instead of waiting for the timeout. Without this
-        // a relay-side rejection looks identical to "no data exists".
+        // CLOSED frame from the relay (rate-limit, auth-required, etc.)
+        // is terminal for this sub *on the sending relay*. In a
+        // multi-relay client the same sub_id may still be alive on a
+        // healthy relay, so we must NOT settle on the first CLOSED —
+        // that would prematurely abort a query other relays could
+        // satisfy. Settle only when ALL connected relays have closed
+        // this sub (no chance of an EOSE-with-data anywhere).
+        // handleClosedMessage records the rejection on the sending
+        // relay's closedSubIds before calling onError, so by the time
+        // we get here we can decide by inspecting that state across
+        // all connected relays.
         onError: (id, message) => {
           console.warn(`Relay closed subscription ${id}: ${message}`);
-          finishWith(pickWinner(), id);
+          const allClosed = Array.from(this.relays.values())
+            .filter((r) => r.connected)
+            .every((r) => r.closedSubIds.has(id));
+          if (allClosed) {
+            finishWith(pickWinner(), id);
+          }
+          // else: keep waiting for EOSE from a healthy relay or the
+          // overall query timeout — no relay can stop the world for
+          // others.
         },
       });
     });

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -423,10 +423,12 @@ export class NostrClient {
               // longer counts toward "still pending" relays. Firing
               // a synthetic onError gives every active sub a chance
               // to re-evaluate now that the relay set has shrunk.
+              // Include the relay URL so listeners in a multi-relay
+              // client can attribute which relay dropped.
               const inflight = Array.from(this.subscriptions.entries());
               for (const [subId, sub] of inflight) {
                 try {
-                  sub.listener.onError?.(subId, `Relay disconnected: ${reason}`);
+                  sub.listener.onError?.(subId, `Relay disconnected (${url}): ${reason}`);
                 } catch {
                   // Ignore listener errors — we're notifying
                   // best-effort.
@@ -1197,6 +1199,15 @@ export class NostrClient {
       subscriptionId = `sub_${++this.subscriptionCounter}`;
       filter = filterOrSubId;
       listener = listenerOrFilter as NostrEventListener;
+    }
+
+    // Reserved prefix for SDK-internal sub_ids (currently just the
+    // keepalive `PING_SUB_ID`). Reject explicit caller use so the
+    // keepalive timer's CLOSE/REQ cycle can't stomp on user state.
+    if (subscriptionId.startsWith('__nostr-sdk-')) {
+      throw new Error(
+        `Subscription ID "${subscriptionId}" uses the reserved "__nostr-sdk-" prefix — pick a different id.`,
+      );
     }
 
     this.subscriptions.set(subscriptionId, { filter, listener });

--- a/src/client/NostrClient.ts
+++ b/src/client/NostrClient.ts
@@ -279,14 +279,24 @@ export class NostrClient {
     }
 
     return new Promise((resolve, reject) => {
-      // `timedOut` is observed inside the createWebSocket .then below.
-      // Without it, a slow socket creation that resolves AFTER we've
-      // already rejected the outer promise would still register the
-      // socket in this.relays and start a pingTimer — orphan
-      // resources the caller can't see or clean up.
+      // The connection-setup timeout has three races to defend
+      // against:
+      //   A) createWebSocket resolves AFTER the timeout fired.
+      //   B) createWebSocket resolves BEFORE the timeout, but
+      //      `onopen` fires AFTER the timeout fired.
+      //   C) createWebSocket resolves and `onopen` fires BEFORE the
+      //      timeout (the success path).
+      // `pendingSocket` lets the timeout proactively close any
+      // socket that's already been created but hasn't fired
+      // `onopen` yet. The `timedOut` flag covers (A) inside `.then`
+      // and (B) inside `socket.onopen`.
       let timedOut = false;
+      let pendingSocket: IWebSocket | null = null;
       const timeoutId = setTimeout(() => {
         timedOut = true;
+        if (pendingSocket) {
+          try { pendingSocket.close(1000, 'Connection setup timed out'); } catch { /* ignore */ }
+        }
         reject(new Error(`Connection to ${url} timed out`));
       }, CONNECTION_TIMEOUT_MS);
 
@@ -298,6 +308,7 @@ export class NostrClient {
             try { socket.close(1000, 'Connection setup timed out'); } catch { /* ignore */ }
             return;
           }
+          pendingSocket = socket;
           const relay: RelayConnection = {
             url,
             socket,
@@ -317,6 +328,18 @@ export class NostrClient {
           };
 
           socket.onopen = () => {
+            // The `.then` block already guards against a socket
+            // arriving after the connection timeout, but the socket
+            // can also be created BEFORE the timeout while
+            // `onopen` fires AFTER the timeout has rejected the
+            // outer promise. Without this second guard we'd register
+            // the relay, start a pingTimer, and resubscribe — orphan
+            // background resources the caller can't see or clean up
+            // because their connect() call already saw a rejection.
+            if (timedOut) {
+              try { socket.close(1000, 'Connection setup timed out'); } catch { /* ignore */ }
+              return;
+            }
             clearTimeout(timeoutId);
             relay.connected = true;
             relay.reconnectAttempts = 0;  // Reset on successful connection
@@ -366,6 +389,25 @@ export class NostrClient {
             if (wasConnected) {
               const reason = event?.reason || 'Connection closed';
               this.emitConnectionEvent('disconnect', url, reason);
+
+              // Re-trigger the all-done check on every active sub.
+              // queryWithFirstSeenWins.allRelaysDoneFor only runs
+              // from listener callbacks (EOSE / CLOSED via onError);
+              // a socket that drops without sending either would
+              // otherwise leave the query hanging until
+              // queryTimeoutMs even though the disconnected relay no
+              // longer counts toward "still pending" relays. Firing
+              // a synthetic onError gives every active sub a chance
+              // to re-evaluate now that the relay set has shrunk.
+              const inflight = Array.from(this.subscriptions.entries());
+              for (const [subId, sub] of inflight) {
+                try {
+                  sub.listener.onError?.(subId, `Relay disconnected: ${reason}`);
+                } catch {
+                  // Ignore listener errors — we're notifying
+                  // best-effort.
+                }
+              }
             }
 
             if (!this.closed && this.autoReconnect && !relay.reconnecting) {
@@ -380,7 +422,11 @@ export class NostrClient {
             }
           };
 
-          this.relays.set(url, relay);
+          // Note: we do NOT register the relay in `this.relays` here —
+          // only after `onopen` fires successfully. Registering eagerly
+          // (before onopen) would leak the relay into the global map
+          // even when the connection setup times out and the caller's
+          // promise has already rejected.
         })
         .catch((error) => {
           clearTimeout(timeoutId);

--- a/tests/integration/relay-fixes-e2e.test.ts
+++ b/tests/integration/relay-fixes-e2e.test.ts
@@ -1,0 +1,192 @@
+/**
+ * End-to-end tests for the relay-resilience fixes (issue #7) against the
+ * live testnet relay at wss://nostr-relay.testnet.unicity.network.
+ *
+ * Each test connects with a fresh keypair so it cannot collide with other
+ * sessions and so the keepalive sub_id "ping" gets a deterministic
+ * authors:[selfPubkey] filter.
+ *
+ * These tests are skipped automatically by the default vitest config
+ * (which excludes tests/integration/**); run them with
+ *   npm run test:integration -- relay-fixes-e2e
+ * or
+ *   RELAY_URL=wss://other-relay vitest run tests/integration/relay-fixes-e2e.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { NostrClient } from '../../src/client/NostrClient.js';
+import { NostrKeyManager } from '../../src/NostrKeyManager.js';
+import { Filter } from '../../src/protocol/Filter.js';
+import * as EventKinds from '../../src/protocol/EventKinds.js';
+import WebSocket from 'ws';
+
+const RELAY_URL = process.env.RELAY_URL ?? 'wss://nostr-relay.testnet.unicity.network';
+// Known nametag with a published binding on testnet, used as a positive
+// control for queryPubkeyByNametag.
+const KNOWN_NAMETAG = 'unichess';
+// Long random string that will not collide with any registered nametag.
+const UNREGISTERED_NAMETAG = `e2e-test-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+
+describe('E2E: relay resilience fixes (issue #7)', () => {
+  let client: NostrClient;
+
+  beforeEach(() => {
+    client = new NostrClient(NostrKeyManager.generate(), {
+      // Short ping interval so we can exercise the keepalive REQ shape
+      // without hanging the test runner.
+      pingIntervalMs: 2000,
+      queryTimeoutMs: 8000,
+      autoReconnect: false,
+    });
+  });
+
+  afterEach(() => {
+    try { client.disconnect(); } catch { /* ignore */ }
+  });
+
+  it('queryPubkeyByNametag resolves a known nametag from the live relay', async () => {
+    await client.connect(RELAY_URL);
+
+    const start = Date.now();
+    const pubkey = await client.queryPubkeyByNametag(KNOWN_NAMETAG);
+    const elapsed = Date.now() - start;
+
+    expect(pubkey).toBeTruthy();
+    expect(pubkey).toMatch(/^[0-9a-f]{64}$/);
+    // Should not require the full queryTimeoutMs.
+    expect(elapsed).toBeLessThan(6000);
+  }, 20_000);
+
+  it('queryPubkeyByNametag returns null for an unregistered nametag without hanging', async () => {
+    await client.connect(RELAY_URL);
+
+    const start = Date.now();
+    const pubkey = await client.queryPubkeyByNametag(UNREGISTERED_NAMETAG);
+    const elapsed = Date.now() - start;
+
+    expect(pubkey).toBeNull();
+    // EOSE should arrive quickly for a tag-indexed lookup with zero
+    // matches. We give some slack for relay latency but this should not
+    // approach the 8s queryTimeoutMs.
+    expect(elapsed).toBeLessThan(7500);
+  }, 20_000);
+
+  it('keepalive REQ on the live relay does NOT trigger a global event firehose', async () => {
+    // We connect for real, then reach into the SDK's per-relay socket
+    // and wrap its send() method to capture exactly what goes on the
+    // wire. This is more reliable than monkey-patching the `ws`
+    // module because the SDK's WebSocketAdapter dynamically imports
+    // `ws`, and the prototype we'd patch via a top-level `import` may
+    // not be the same instance.
+
+    await client.connect(RELAY_URL);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const relays: Map<string, { socket: { send: (msg: string) => void } }> = (client as any).relays;
+    const relay = relays.get(RELAY_URL);
+    expect(relay).toBeDefined();
+
+    const sentFrames: string[] = [];
+    const origSend = relay!.socket.send.bind(relay!.socket);
+    relay!.socket.send = (msg: string) => {
+      sentFrames.push(msg);
+      return origSend(msg);
+    };
+
+    // Wait for at least one ping cycle (pingIntervalMs is 2000, so 2.5s
+    // gives one tick comfortably even under timer skew).
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // Also count any incoming events on sub_id "ping" — if the live tail
+    // is firehose'd, we'll see them within this window.
+    let pingEventCount = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const onmessage = (relay!.socket as any).onmessage as ((e: { data: string }) => void) | null;
+    if (onmessage) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (relay!.socket as any).onmessage = (e: { data: string }) => {
+        try {
+          const frame = JSON.parse(e.data);
+          if (Array.isArray(frame) && frame[0] === 'EVENT' && frame[1] === 'ping') {
+            pingEventCount++;
+          }
+        } catch { /* ignore */ }
+        onmessage(e);
+      };
+    }
+    // Wait another full ping cycle so we actually have a chance to
+    // receive the live-tail firehose if it were broken.
+    await new Promise((r) => setTimeout(r, 2500));
+
+    const pingReqFrame = sentFrames
+      .map((m) => { try { return JSON.parse(m); } catch { return undefined; } })
+      .find((m) => Array.isArray(m) && m[0] === 'REQ' && m[1] === 'ping') as unknown[] | undefined;
+
+    expect(pingReqFrame).toBeDefined();
+    expect(pingReqFrame![0]).toBe('REQ');
+    expect(pingReqFrame![1]).toBe('ping');
+
+    const filter = pingReqFrame![2] as { authors?: string[]; limit?: number };
+    expect(filter.authors).toBeDefined();
+    expect(Array.isArray(filter.authors)).toBe(true);
+    expect(filter.authors!.length).toBe(1);
+    expect(filter.authors![0]).toMatch(/^[0-9a-f]{64}$/);
+    expect(filter.limit).toBe(1);
+    expect((filter as Record<string, unknown>).kinds).toBeUndefined();
+    expect((filter as Record<string, unknown>)['#p']).toBeUndefined();
+
+    // Critical regression check: with the broken `{limit:1}` filter,
+    // the relay would be streaming kind-1059 / 31113 events through
+    // sub_id "ping" continuously (≈10/s). With the scoped filter,
+    // there should be 0 (or at most a single own-publish on first
+    // cycle; we use a fresh keypair so that case is excluded).
+    expect(pingEventCount).toBe(0);
+  }, 30_000);
+
+  it('CLOSED frame from relay settles a query without consuming the full timeout', async () => {
+    // We can't reliably trip the relay's per-connection sub limit from a
+    // unit test, so we exercise the same code path by rapidly opening a
+    // tightly-scoped query, then injecting a synthetic CLOSED frame at
+    // the WebSocketAdapter level by reaching into the SDK's relay map.
+    //
+    // This proves the wiring (queryWithFirstSeenWins surfaces CLOSED →
+    // settles) end-to-end against a real connection. The pure filter /
+    // protocol behavior is already covered by the unit test.
+    await client.connect(RELAY_URL);
+
+    // Kick off a query the relay would have to crawl indexes for.
+    const queryStart = Date.now();
+    const queryPromise = client.queryPubkeyByNametag(UNREGISTERED_NAMETAG);
+
+    // Reach into the client to find the auto-generated sub_id for this
+    // query and inject a CLOSED frame as if the relay sent it. This is
+    // the exact wire path that fires under max_subscriptions exhaustion.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const subs: Map<string, unknown> = (client as any).subscriptions;
+    const querySubId = Array.from(subs.keys()).find((k) => k.startsWith('sub_'));
+    expect(querySubId).toBeDefined();
+
+    // Pull the live relay socket and drive a CLOSED message at it.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const relays: Map<string, { socket: { onmessage?: (e: { data: string }) => void } }> = (client as any).relays;
+    const relay = relays.get(RELAY_URL);
+    expect(relay).toBeDefined();
+    expect(relay!.socket.onmessage).toBeDefined();
+
+    relay!.socket.onmessage!({
+      data: JSON.stringify(['CLOSED', querySubId, 'error: Maximum concurrent subscription count reached']),
+    });
+
+    const result = await queryPromise;
+    const elapsed = Date.now() - queryStart;
+
+    expect(result).toBeNull();
+    // Should resolve nearly immediately after CLOSED, NOT wait for the
+    // full queryTimeoutMs.
+    expect(elapsed).toBeLessThan(2000);
+
+    // And the rejected sub must be cleaned up so resubscribeAll cannot
+    // re-issue it on a future reconnect.
+    expect(subs.has(querySubId!)).toBe(false);
+  }, 20_000);
+});

--- a/tests/integration/relay-fixes-e2e.test.ts
+++ b/tests/integration/relay-fixes-e2e.test.ts
@@ -3,14 +3,15 @@
  * live testnet relay at wss://nostr-relay.testnet.unicity.network.
  *
  * Each test connects with a fresh keypair so it cannot collide with other
- * sessions and so the keepalive sub_id "ping" gets a deterministic
- * authors:[selfPubkey] filter.
+ * sessions and so the keepalive sub_id "__nostr-sdk-keepalive__" gets a
+ * deterministic authors:[selfPubkey] filter.
  *
- * These tests are skipped automatically by the default vitest config
- * (which excludes tests/integration/**); run them with
+ * The default vitest config excludes tests/integration/**, so these
+ * tests do NOT run via `npm test` / `npm run test:unit`. Run them with
+ * the integration config:
  *   npm run test:integration -- relay-fixes-e2e
  * or
- *   RELAY_URL=wss://other-relay vitest run tests/integration/relay-fixes-e2e.test.ts
+ *   RELAY_URL=wss://other-relay npm run test:integration -- relay-fixes-e2e
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';

--- a/tests/integration/relay-fixes-e2e.test.ts
+++ b/tests/integration/relay-fixes-e2e.test.ts
@@ -3,8 +3,8 @@
  * live testnet relay at wss://nostr-relay.testnet.unicity.network.
  *
  * Each test connects with a fresh keypair so it cannot collide with other
- * sessions and so the keepalive sub_id "__nostr-sdk-keepalive__" gets a
- * deterministic authors:[selfPubkey] filter.
+ * sessions and so the keepalive sub gets a deterministic, unreachable
+ * filter.
  *
  * The default vitest config excludes tests/integration/**, so these
  * tests do NOT run via `npm test` / `npm run test:unit`. Run them with
@@ -27,9 +27,11 @@ const UNREGISTERED_NAMETAG = `e2e-test-${Date.now().toString(36)}-${Math.random(
 
 describe('E2E: relay resilience fixes (issue #7)', () => {
   let client: NostrClient;
+  let clientKeys: NostrKeyManager;
 
   beforeEach(() => {
-    client = new NostrClient(NostrKeyManager.generate(), {
+    clientKeys = NostrKeyManager.generate();
+    client = new NostrClient(clientKeys, {
       // Short ping interval so we can exercise the keepalive REQ shape
       // without hanging the test runner.
       pingIntervalMs: 2000,
@@ -113,10 +115,24 @@ describe('E2E: relay resilience fixes (issue #7)', () => {
       if (origOnMessage) origOnMessage(e);
     };
 
-    // Now wait long enough for at least two ping cycles (pingIntervalMs
-    // = 2000) to see both the send-side REQ shape AND any incoming
-    // live-tail traffic on the "ping" sub.
-    await new Promise((r) => setTimeout(r, 5000));
+    // Wait one ping cycle so the REQ goes out, then publish a real
+    // event from this same key. The previous version of this test
+    // relied on "fresh keypair publishes nothing, so live tail sees
+    // nothing" — that hid the bug where `authors:[self]` matched
+    // every event the wallet itself publishes. Now we publish a real
+    // kind-31113 event during the second cycle and assert it does NOT
+    // come back on the keepalive sub.
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // Publish a kind-31113 token-transfer-shaped event from the SAME
+    // pubkey driving the keepalive. With the broken filter the relay
+    // echoes this back on `__nostr-sdk-keepalive__` within ms.
+    const recipientPubkey = NostrKeyManager.generate().getPublicKeyHex();
+    await client.sendTokenTransfer(recipientPubkey, JSON.stringify({ probe: 'keepalive-leak-check' }));
+
+    // Wait long enough for at least one more ping cycle and for the
+    // relay's live-tail forwarding to fire if the filter were broken.
+    await new Promise((r) => setTimeout(r, 3000));
 
     const pingReqFrame = sentFrames
       .map((m) => { try { return JSON.parse(m); } catch { return undefined; } })
@@ -126,20 +142,23 @@ describe('E2E: relay resilience fixes (issue #7)', () => {
     expect(pingReqFrame![0]).toBe('REQ');
     expect(pingReqFrame![1]).toBe('__nostr-sdk-keepalive__');
 
-    const filter = pingReqFrame![2] as { authors?: string[]; limit?: number };
-    expect(filter.authors).toBeDefined();
-    expect(Array.isArray(filter.authors)).toBe(true);
-    expect(filter.authors!.length).toBe(1);
-    expect(filter.authors![0]).toMatch(/^[0-9a-f]{64}$/);
+    // Filter must use the unreachable id pattern — NOT authors:[self],
+    // which would match every event the wallet itself publishes.
+    const filter = pingReqFrame![2] as Record<string, unknown>;
+    expect(filter.ids).toEqual(['0'.repeat(64)]);
     expect(filter.limit).toBe(1);
-    expect((filter as Record<string, unknown>).kinds).toBeUndefined();
-    expect((filter as Record<string, unknown>)['#p']).toBeUndefined();
+    expect(filter.authors).toBeUndefined();
+    expect(filter.kinds).toBeUndefined();
+    expect(filter['#p']).toBeUndefined();
+    // Defense-in-depth: the wallet pubkey must not appear anywhere in
+    // the filter, no matter the encoding.
+    expect(JSON.stringify(filter)).not.toContain(clientKeys.getPublicKeyHex());
 
-    // Critical regression check: with the broken `{limit:1}` filter,
-    // the relay would be streaming kind-1059 / 31113 events through
-    // sub_id "ping" continuously (≈10/s). With the scoped filter,
-    // there should be 0 (or at most a single own-publish on first
-    // cycle; we use a fresh keypair so that case is excluded).
+    // The actual regression check: with the broken `authors:[self]`
+    // filter, the kind-31113 publish above would be echoed back on
+    // sub_id `__nostr-sdk-keepalive__` (since the wallet is the
+    // author). With the unreachable-id filter, the live tail never
+    // matches and pingEventCount stays 0.
     expect(pingEventCount).toBe(0);
   }, 30_000);
 

--- a/tests/integration/relay-fixes-e2e.test.ts
+++ b/tests/integration/relay-fixes-e2e.test.ts
@@ -16,9 +16,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { NostrClient } from '../../src/client/NostrClient.js';
 import { NostrKeyManager } from '../../src/NostrKeyManager.js';
-import { Filter } from '../../src/protocol/Filter.js';
-import * as EventKinds from '../../src/protocol/EventKinds.js';
-import WebSocket from 'ws';
 
 const RELAY_URL = process.env.RELAY_URL ?? 'wss://nostr-relay.testnet.unicity.network';
 // Known nametag with a published binding on testnet, used as a positive

--- a/tests/integration/relay-fixes-e2e.test.ts
+++ b/tests/integration/relay-fixes-e2e.test.ts
@@ -83,6 +83,14 @@ describe('E2E: relay resilience fixes (issue #7)', () => {
     const relay = relays.get(RELAY_URL);
     expect(relay).toBeDefined();
 
+    // Wrap BOTH socket.send (to capture the ping REQ shape) AND
+    // socket.onmessage (to count any incoming live-tail EVENTs)
+    // BEFORE waiting for any ping cycles. The previous version
+    // installed the onmessage wrapper after the first 2.5s wait —
+    // a buggy `{limit:1}` filter would send live-tail events
+    // immediately after the first REQ/EOSE round-trip and those
+    // would land before the wrapper was attached, giving a false
+    // negative.
     const sentFrames: string[] = [];
     const origSend = relay!.socket.send.bind(relay!.socket);
     relay!.socket.send = (msg: string) => {
@@ -90,30 +98,24 @@ describe('E2E: relay resilience fixes (issue #7)', () => {
       return origSend(msg);
     };
 
-    // Wait for at least one ping cycle (pingIntervalMs is 2000, so 2.5s
-    // gives one tick comfortably even under timer skew).
-    await new Promise((r) => setTimeout(r, 2500));
-
-    // Also count any incoming events on sub_id "ping" — if the live tail
-    // is firehose'd, we'll see them within this window.
     let pingEventCount = 0;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const onmessage = (relay!.socket as any).onmessage as ((e: { data: string }) => void) | null;
-    if (onmessage) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (relay!.socket as any).onmessage = (e: { data: string }) => {
-        try {
-          const frame = JSON.parse(e.data);
-          if (Array.isArray(frame) && frame[0] === 'EVENT' && frame[1] === 'ping') {
-            pingEventCount++;
-          }
-        } catch { /* ignore */ }
-        onmessage(e);
-      };
-    }
-    // Wait another full ping cycle so we actually have a chance to
-    // receive the live-tail firehose if it were broken.
-    await new Promise((r) => setTimeout(r, 2500));
+    const origOnMessage = (relay!.socket as any).onmessage as ((e: { data: string }) => void) | null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (relay!.socket as any).onmessage = (e: { data: string }) => {
+      try {
+        const frame = JSON.parse(e.data);
+        if (Array.isArray(frame) && frame[0] === 'EVENT' && frame[1] === 'ping') {
+          pingEventCount++;
+        }
+      } catch { /* ignore */ }
+      if (origOnMessage) origOnMessage(e);
+    };
+
+    // Now wait long enough for at least two ping cycles (pingIntervalMs
+    // = 2000) to see both the send-side REQ shape AND any incoming
+    // live-tail traffic on the "ping" sub.
+    await new Promise((r) => setTimeout(r, 5000));
 
     const pingReqFrame = sentFrames
       .map((m) => { try { return JSON.parse(m); } catch { return undefined; } })

--- a/tests/integration/relay-fixes-e2e.test.ts
+++ b/tests/integration/relay-fixes-e2e.test.ts
@@ -105,7 +105,7 @@ describe('E2E: relay resilience fixes (issue #7)', () => {
     (relay!.socket as any).onmessage = (e: { data: string }) => {
       try {
         const frame = JSON.parse(e.data);
-        if (Array.isArray(frame) && frame[0] === 'EVENT' && frame[1] === 'ping') {
+        if (Array.isArray(frame) && frame[0] === 'EVENT' && frame[1] === '__nostr-sdk-keepalive__') {
           pingEventCount++;
         }
       } catch { /* ignore */ }
@@ -119,11 +119,11 @@ describe('E2E: relay resilience fixes (issue #7)', () => {
 
     const pingReqFrame = sentFrames
       .map((m) => { try { return JSON.parse(m); } catch { return undefined; } })
-      .find((m) => Array.isArray(m) && m[0] === 'REQ' && m[1] === 'ping') as unknown[] | undefined;
+      .find((m) => Array.isArray(m) && m[0] === 'REQ' && m[1] === '__nostr-sdk-keepalive__') as unknown[] | undefined;
 
     expect(pingReqFrame).toBeDefined();
     expect(pingReqFrame![0]).toBe('REQ');
-    expect(pingReqFrame![1]).toBe('ping');
+    expect(pingReqFrame![1]).toBe('__nostr-sdk-keepalive__');
 
     const filter = pingReqFrame![2] as { authors?: string[]; limit?: number };
     expect(filter.authors).toBeDefined();

--- a/tests/integration/two-party-flow-relay.test.ts
+++ b/tests/integration/two-party-flow-relay.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Two-party end-to-end test: Alice publishes a real token transfer to
+ * Bob, Bob's consumer subscription receives it, and Alice's keepalive
+ * sub does NOT echo Alice's own publish back.
+ *
+ * This test runs in two modes:
+ *   1. Against a containerised unicity-tokens-relay (default; hermetic).
+ *      The image is pulled from
+ *      `ghcr.io/unicitynetwork/unicity-tokens-relay:latest`.
+ *   2. Against a deployed relay, by setting RELAY_URL=wss://...
+ *      Use this for "does my fix actually work in production?" checks.
+ *
+ *   $ npm run test:integration -- two-party-flow-relay
+ *   $ RELAY_URL=wss://nostr-relay.testnet.unicity.network npm run test:integration -- two-party-flow-relay
+ *
+ * This is the test the previous fix was missing. Earlier coverage
+ * asserted the SHAPE of the keepalive REQ filter, then locked in
+ * `authors:[self]` as the expected shape — so when that filter was
+ * actually wrong (it matched every event the wallet itself published
+ * and the relay echoed each one back on the keepalive sub), the tests
+ * confirmed the bug rather than catching it. This test asserts
+ * BEHAVIOR — what actually arrives on the wire — which is what
+ * matters.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { GenericContainer, StartedTestContainer, Wait } from 'testcontainers';
+import { NostrClient } from '../../src/client/NostrClient.js';
+import { NostrKeyManager } from '../../src/NostrKeyManager.js';
+import { Filter } from '../../src/protocol/Filter.js';
+import * as EventKinds from '../../src/protocol/EventKinds.js';
+import type { Event } from '../../src/protocol/Event.js';
+
+const RELAY_INTERNAL_PORT = 8080;
+const STARTUP_TIMEOUT_MS = 60_000;
+
+// Mode is decided once per test file:
+//   - RELAY_URL=wss://...    → use that, skip container startup
+//   - (unset)                → spin up the unicity-tokens-relay image
+const EXTERNAL_RELAY_URL = process.env.RELAY_URL?.trim();
+const USE_CONTAINER = !EXTERNAL_RELAY_URL;
+
+describe('E2E: two-party token transfer + keepalive isolation', () => {
+  let container: StartedTestContainer | undefined;
+  let relayUrl: string;
+
+  beforeAll(async () => {
+    if (USE_CONTAINER) {
+      container = await new GenericContainer('ghcr.io/unicitynetwork/unicity-tokens-relay:latest')
+        // Force linux/amd64 so the image runs unmodified on Apple
+        // Silicon dev machines (the published image only ships an
+        // amd64 manifest). Docker Desktop / colima run it under
+        // emulation; CI runners on linux/amd64 hit the native path.
+        .withPlatform('linux/amd64')
+        .withExposedPorts(RELAY_INTERNAL_PORT)
+        // Most nostr-rs-relay-style images log a "listening on" line
+        // shortly after startup. The permissive log match also covers
+        // "ready" / "started" banners; falls back to startup timeout
+        // if the image diverges.
+        .withWaitStrategy(Wait.forLogMessage(/listening|ready|started/i, 1))
+        .withStartupTimeout(STARTUP_TIMEOUT_MS)
+        .start();
+
+      const port = container.getMappedPort(RELAY_INTERNAL_PORT);
+      relayUrl = `ws://localhost:${port}`;
+      // Brief settle delay so the relay's WS upgrade handler is wired
+      // before the first connect attempt.
+      await new Promise((r) => setTimeout(r, 500));
+    } else {
+      relayUrl = EXTERNAL_RELAY_URL!;
+    }
+  }, STARTUP_TIMEOUT_MS + 5_000);
+
+  afterAll(async () => {
+    if (container) {
+      try { await container.stop(); } catch { /* ignore */ }
+    }
+  });
+
+  let aliceKeys: NostrKeyManager;
+  let bobKeys: NostrKeyManager;
+  let alice: NostrClient;
+  let bob: NostrClient;
+
+  beforeEach(() => {
+    aliceKeys = NostrKeyManager.generate();
+    bobKeys = NostrKeyManager.generate();
+    // Short ping interval so we cover at least one keepalive REQ
+    // cycle in-test without sleeping forever.
+    const opts = { pingIntervalMs: 2000, queryTimeoutMs: 8000, autoReconnect: false };
+    alice = new NostrClient(aliceKeys, opts);
+    bob = new NostrClient(bobKeys, opts);
+  });
+
+  afterEach(() => {
+    try { alice.disconnect(); } catch { /* ignore */ }
+    try { bob.disconnect(); } catch { /* ignore */ }
+  });
+
+  it('Alice → Bob token transfer is received and NOT echoed on Alice\'s keepalive sub', async () => {
+    await Promise.all([alice.connect(relayUrl), bob.connect(relayUrl)]);
+
+    // Wrap Alice's socket to count any frames the relay sends on her
+    // keepalive sub. With a correct filter this stays at 0 even when
+    // she publishes events.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const aliceRelays: Map<string, { socket: { onmessage: ((e: { data: string }) => void) | null } }> = (alice as any).relays;
+    const aliceRelay = aliceRelays.get(relayUrl);
+    expect(aliceRelay).toBeDefined();
+
+    let pingEchoCount = 0;
+    const origOnMessage = aliceRelay!.socket.onmessage;
+    aliceRelay!.socket.onmessage = (e: { data: string }) => {
+      try {
+        const frame = JSON.parse(e.data);
+        if (Array.isArray(frame) && frame[0] === 'EVENT' && frame[1] === '__nostr-sdk-keepalive__') {
+          pingEchoCount++;
+        }
+      } catch { /* ignore non-JSON */ }
+      if (origOnMessage) origOnMessage(e);
+    };
+
+    // Bob subscribes for incoming token transfers addressed to him.
+    let bobReceivedResolve!: (event: Event) => void;
+    const bobReceivedPromise = new Promise<Event>((resolve) => {
+      bobReceivedResolve = resolve;
+    });
+
+    bob.subscribe(
+      Filter.builder()
+        .kinds(EventKinds.TOKEN_TRANSFER)
+        .pTags(bobKeys.getPublicKeyHex())
+        .build(),
+      {
+        onEvent: (event: Event) => bobReceivedResolve(event),
+      },
+    );
+
+    // Wait for the subscription to settle (relay sends EOSE for the
+    // initial empty result set), and for at least one keepalive cycle
+    // to fire on Alice so any broken filter would already be live.
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // Alice publishes a real token transfer to Bob.
+    const tokenJson = JSON.stringify({ probe: 'two-party-flow', ts: Date.now() });
+    const eventId = await alice.sendTokenTransfer(bobKeys.getPublicKeyHex(), tokenJson);
+    expect(eventId).toMatch(/^[0-9a-f]{64}$/);
+
+    // Bob should receive it within a few seconds.
+    const received = await Promise.race([
+      bobReceivedPromise,
+      new Promise<never>((_, rej) =>
+        setTimeout(() => rej(new Error('Bob did not receive Alice\'s transfer in time')), 8000)),
+    ]);
+    expect(received.id).toBe(eventId);
+    expect(received.kind).toBe(EventKinds.TOKEN_TRANSFER);
+    expect(received.pubkey).toBe(aliceKeys.getPublicKeyHex());
+
+    // Wait one more keepalive cycle so any post-publish live-tail
+    // delivery would have arrived by now.
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // Regression check: the keepalive sub on Alice's connection must
+    // not have received any EVENTs. The previous `authors:[self]`
+    // filter would have echoed the kind-31113 publish back here.
+    expect(pingEchoCount).toBe(0);
+  }, 30_000);
+
+  it('Bob → Alice round-trip works while keepalive is active on both', async () => {
+    // Symmetric variant: Alice subscribes to events addressed to
+    // herself and Bob sends. This catches the scenario where a relay
+    // dedupes events across overlapping subs — if Alice's keepalive
+    // matched the same event her consumer sub does, on some relays
+    // only one sub gets the delivery and the wallet's flow breaks.
+    // With the unreachable-id keepalive filter, no overlap is
+    // possible.
+    await Promise.all([alice.connect(relayUrl), bob.connect(relayUrl)]);
+
+    let resolveReceived!: (event: Event) => void;
+    const receivedPromise = new Promise<Event>((resolve) => {
+      resolveReceived = resolve;
+    });
+
+    alice.subscribe(
+      Filter.builder()
+        .kinds(EventKinds.TOKEN_TRANSFER)
+        .pTags(aliceKeys.getPublicKeyHex())
+        .build(),
+      {
+        onEvent: (event: Event) => resolveReceived(event),
+      },
+    );
+
+    await new Promise((r) => setTimeout(r, 2500));
+    const eventId = await bob.sendTokenTransfer(
+      aliceKeys.getPublicKeyHex(),
+      JSON.stringify({ probe: 'reverse-direction' }),
+    );
+
+    const received = await Promise.race([
+      receivedPromise,
+      new Promise<never>((_, rej) =>
+        setTimeout(() => rej(new Error('Alice did not receive Bob\'s transfer')), 8000)),
+    ]);
+    expect(received.id).toBe(eventId);
+    expect(received.pubkey).toBe(bobKeys.getPublicKeyHex());
+  }, 30_000);
+});

--- a/tests/unit/reconnection.test.ts
+++ b/tests/unit/reconnection.test.ts
@@ -215,16 +215,19 @@ describe('NostrClient Reconnection', () => {
       await connectClient();
 
       await vi.advanceTimersByTimeAsync(PING_INTERVAL);
-      const pings = fakeSocket.sentMessages.filter(m => m.includes('"ping"'));
-      expect(pings.length).toBe(2); // CLOSE ping + REQ ping
-      expect(pings[0]).toBe(JSON.stringify(['CLOSE', 'ping']));
+      // The keepalive uses an internal-namespaced sub_id so user
+      // code can't collide with it.
+      const pingSubId = '__nostr-sdk-keepalive__';
+      const pings = fakeSocket.sentMessages.filter(m => m.includes(JSON.stringify(pingSubId)));
+      expect(pings.length).toBe(2); // CLOSE + REQ
+      expect(pings[0]).toBe(JSON.stringify(['CLOSE', pingSubId]));
       // The REQ filter MUST include `authors:[selfPubkey]` — otherwise after
       // EOSE the relay streams every event it receives back through this sub
       // (NIP-01 live tail), exhausting per-connection subscription slots and
       // wasting bandwidth.
       const reqFrame = JSON.parse(pings[1]);
       expect(reqFrame[0]).toBe('REQ');
-      expect(reqFrame[1]).toBe('ping');
+      expect(reqFrame[1]).toBe(pingSubId);
       expect(reqFrame[2].authors).toEqual([keyManager.getPublicKeyHex()]);
       expect(reqFrame[2].limit).toBe(1);
     });
@@ -253,7 +256,7 @@ describe('NostrClient Reconnection', () => {
       for (let i = 0; i < 10; i++) {
         await vi.advanceTimersByTimeAsync(PING_INTERVAL);
         // Relay responds — resets unansweredPings and lastPongTime
-        fakeSocket._triggerMessage(JSON.stringify(['EOSE', 'ping']));
+        fakeSocket._triggerMessage(JSON.stringify(['EOSE', '__nostr-sdk-keepalive__']));
       }
 
       expect(fakeSocket.closeCalls.length).toBe(0);
@@ -288,7 +291,7 @@ describe('NostrClient Reconnection', () => {
       // Relay is alive for 5 cycles
       for (let i = 0; i < 5; i++) {
         await vi.advanceTimersByTimeAsync(PING_INTERVAL);
-        fakeSocket._triggerMessage(JSON.stringify(['EOSE', 'ping']));
+        fakeSocket._triggerMessage(JSON.stringify(['EOSE', '__nostr-sdk-keepalive__']));
       }
       expect(fakeSocket.closeCalls.length).toBe(0);
 

--- a/tests/unit/reconnection.test.ts
+++ b/tests/unit/reconnection.test.ts
@@ -211,7 +211,7 @@ describe('NostrClient Reconnection', () => {
       fakeSocket.sentMessages.length = 0;
     }
 
-    it('should send ping REQ at each interval, scoped to self to avoid live-tail firehose', async () => {
+    it('should send ping REQ at each interval, scoped to an unreachable id (no live-tail firehose, no self-echo)', async () => {
       await connectClient();
 
       await vi.advanceTimersByTimeAsync(PING_INTERVAL);
@@ -221,15 +221,22 @@ describe('NostrClient Reconnection', () => {
       const pings = fakeSocket.sentMessages.filter(m => m.includes(JSON.stringify(pingSubId)));
       expect(pings.length).toBe(2); // CLOSE + REQ
       expect(pings[0]).toBe(JSON.stringify(['CLOSE', pingSubId]));
-      // The REQ filter MUST include `authors:[selfPubkey]` — otherwise after
-      // EOSE the relay streams every event it receives back through this sub
-      // (NIP-01 live tail), exhausting per-connection subscription slots and
-      // wasting bandwidth.
+
+      // The REQ filter MUST be unreachable. Earlier `authors:[self]`
+      // scoping was wrong — it matched every event the wallet itself
+      // published (kind-31113 token transfers, DMs, etc.) and the
+      // relay echoed them back on the keepalive sub. Filtering by a
+      // single all-zero event id is unreachable in real id space (real
+      // ids are SHA-256 hashes), so EOSE comes back immediately and
+      // the live tail never matches.
       const reqFrame = JSON.parse(pings[1]);
       expect(reqFrame[0]).toBe('REQ');
       expect(reqFrame[1]).toBe(pingSubId);
-      expect(reqFrame[2].authors).toEqual([keyManager.getPublicKeyHex()]);
+      expect(reqFrame[2].ids).toEqual(['0'.repeat(64)]);
       expect(reqFrame[2].limit).toBe(1);
+      // Regression guard: filter must NOT reference the wallet pubkey.
+      expect(reqFrame[2].authors).toBeUndefined();
+      expect(JSON.stringify(reqFrame)).not.toContain(keyManager.getPublicKeyHex());
     });
 
     it('should close socket after 2 unanswered pings when relay is dead', async () => {

--- a/tests/unit/reconnection.test.ts
+++ b/tests/unit/reconnection.test.ts
@@ -211,14 +211,22 @@ describe('NostrClient Reconnection', () => {
       fakeSocket.sentMessages.length = 0;
     }
 
-    it('should send ping REQ at each interval', async () => {
+    it('should send ping REQ at each interval, scoped to self to avoid live-tail firehose', async () => {
       await connectClient();
 
       await vi.advanceTimersByTimeAsync(PING_INTERVAL);
       const pings = fakeSocket.sentMessages.filter(m => m.includes('"ping"'));
       expect(pings.length).toBe(2); // CLOSE ping + REQ ping
       expect(pings[0]).toBe(JSON.stringify(['CLOSE', 'ping']));
-      expect(pings[1]).toBe(JSON.stringify(['REQ', 'ping', { limit: 1 }]));
+      // The REQ filter MUST include `authors:[selfPubkey]` — otherwise after
+      // EOSE the relay streams every event it receives back through this sub
+      // (NIP-01 live tail), exhausting per-connection subscription slots and
+      // wasting bandwidth.
+      const reqFrame = JSON.parse(pings[1]);
+      expect(reqFrame[0]).toBe('REQ');
+      expect(reqFrame[1]).toBe('ping');
+      expect(reqFrame[2].authors).toEqual([keyManager.getPublicKeyHex()]);
+      expect(reqFrame[2].limit).toBe(1);
     });
 
     it('should close socket after 2 unanswered pings when relay is dead', async () => {

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for the relay-resilience fixes covered by issue #7:
+ *   1. The keepalive "ping" REQ filter must be scoped to authors:[self] so
+ *      the relay does not stream a global live-tail through it after EOSE.
+ *   2. A CLOSED frame from the relay must remove the subscription from the
+ *      client-local map, so reconnect-resubscribe and AUTH-resubscribe do
+ *      not re-issue the rejected REQ.
+ *   3. queryWithFirstSeenWins (used by queryPubkeyByNametag /
+ *      queryBindingByNametag / queryBindingByAddress) must settle promptly
+ *      on a CLOSED frame instead of waiting for the full query timeout —
+ *      otherwise rate-limit rejections look identical to "no data exists".
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NostrClient } from '../../src/client/NostrClient.js';
+import { NostrKeyManager } from '../../src/NostrKeyManager.js';
+import { Filter } from '../../src/protocol/Filter.js';
+import type {
+  IWebSocket,
+  WebSocketMessageEvent,
+} from '../../src/client/WebSocketAdapter.js';
+import { OPEN, CLOSED } from '../../src/client/WebSocketAdapter.js';
+
+vi.mock('../../src/client/WebSocketAdapter.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../src/client/WebSocketAdapter.js')>();
+  return {
+    ...orig,
+    createWebSocket: vi.fn(),
+  };
+});
+import { createWebSocket } from '../../src/client/WebSocketAdapter.js';
+const mockCreateWebSocket = vi.mocked(createWebSocket);
+
+function createFakeSocket(): IWebSocket & {
+  _triggerOpen(): void;
+  _triggerMessage(data: string): void;
+  sentMessages: string[];
+  _readyState: number;
+} {
+  const socket: ReturnType<typeof createFakeSocket> = {
+    _readyState: OPEN,
+    get readyState() { return this._readyState; },
+    onopen: null,
+    onmessage: null,
+    onclose: null,
+    onerror: null,
+    sentMessages: [],
+    send(data: string) { this.sentMessages.push(data); },
+    close() { this._readyState = CLOSED; },
+    _triggerOpen() { if (this.onopen) this.onopen({}); },
+    _triggerMessage(data: string) {
+      if (this.onmessage) this.onmessage({ data } as WebSocketMessageEvent);
+    },
+  };
+  return socket;
+}
+
+describe('Relay resilience fixes (issue #7)', () => {
+  let client: NostrClient;
+  let keyManager: NostrKeyManager;
+  let socket: ReturnType<typeof createFakeSocket>;
+
+  beforeEach(() => {
+    keyManager = NostrKeyManager.generate();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    if (client) client.disconnect();
+    vi.useRealTimers();
+  });
+
+  async function connect(opts?: { pingIntervalMs?: number; queryTimeoutMs?: number }): Promise<void> {
+    client = new NostrClient(keyManager, {
+      pingIntervalMs: opts?.pingIntervalMs ?? 0,        // ping disabled by default in these tests
+      queryTimeoutMs: opts?.queryTimeoutMs ?? 5000,
+    });
+    socket = createFakeSocket();
+    mockCreateWebSocket.mockResolvedValue(socket);
+    const p = client.connect('wss://relay.test');
+    await vi.advanceTimersByTimeAsync(0);
+    socket._triggerOpen();
+    await p;
+    socket.sentMessages.length = 0;
+  }
+
+  describe('ping filter scoping', () => {
+    it('scopes the keepalive REQ to authors:[selfPubkey]', async () => {
+      await connect({ pingIntervalMs: 15000 });
+
+      await vi.advanceTimersByTimeAsync(15000);
+      const reqFrame = socket.sentMessages
+        .map((m) => JSON.parse(m))
+        .find((m) => m[0] === 'REQ' && m[1] === 'ping');
+
+      expect(reqFrame).toBeDefined();
+      expect(reqFrame[2]).toEqual({
+        authors: [keyManager.getPublicKeyHex()],
+        limit: 1,
+      });
+    });
+
+    it('precedes the REQ with a CLOSE for the same sub_id (no slot accumulation)', async () => {
+      await connect({ pingIntervalMs: 15000 });
+
+      await vi.advanceTimersByTimeAsync(15000);
+      const pingFrames = socket.sentMessages
+        .map((m) => JSON.parse(m))
+        .filter((m) => m[1] === 'ping');
+
+      expect(pingFrames.length).toBe(2);
+      expect(pingFrames[0][0]).toBe('CLOSE');
+      expect(pingFrames[1][0]).toBe('REQ');
+    });
+  });
+
+  describe('CLOSED frame handling', () => {
+    it('removes the subscription from the client-local map on CLOSED', async () => {
+      await connect();
+
+      const onError = vi.fn();
+      const subId = client.subscribe(Filter.builder().kinds(1).build(), {
+        onEvent: vi.fn(),
+        onError,
+      });
+
+      // Verify the REQ was sent.
+      expect(socket.sentMessages.some((m) => m.includes(`"REQ","${subId}"`))).toBe(true);
+
+      // Relay rejects with CLOSED (this is what nostr-rs-relay emits when
+      // max_subscriptions is hit).
+      socket._triggerMessage(JSON.stringify(['CLOSED', subId, 'error: rate-limited: too many concurrent REQs']));
+
+      // The listener is notified.
+      expect(onError).toHaveBeenCalledWith(subId, expect.stringContaining('rate-limited'));
+
+      // The Map entry is gone — proven by the fact that a follow-up
+      // EVENT for that sub_id is silently dropped (no listener invocation).
+      // We verify by sending an EVENT and asserting onError isn't called
+      // a second time (the original onEvent handler also wouldn't fire,
+      // but easier to assert what *didn't* happen via call counts).
+      const onEventLater = vi.fn();
+      // Re-subscribe with the same sub_id to prove the slot was freed in
+      // the local map; subscribe assigns a new auto-generated sub_id, so
+      // we're really testing that `subscriptions.has(oldSubId)` is false.
+      client.unsubscribe(subId);   // should be a no-op now — no CLOSE frame emitted
+      const sentBefore = socket.sentMessages.length;
+      client.unsubscribe(subId);
+      expect(socket.sentMessages.length).toBe(sentBefore);
+      expect(onEventLater).not.toHaveBeenCalled();
+    });
+
+    it('does NOT replay a CLOSED-rejected sub on simulated post-AUTH resubscribe', async () => {
+      await connect();
+
+      const subId = client.subscribe(Filter.builder().kinds(1).build(), {
+        onEvent: vi.fn(),
+      });
+      const reqFrame = JSON.stringify(['REQ', subId, Filter.builder().kinds(1).build().toJSON()]);
+
+      // Initial REQ went out.
+      expect(socket.sentMessages).toContain(reqFrame);
+
+      // Relay rejects.
+      socket._triggerMessage(JSON.stringify(['CLOSED', subId, 'error: auth-required']));
+
+      // Simulate post-AUTH resubscribe by triggering an AUTH challenge —
+      // resubscribeAll runs after AUTH_RESUBSCRIBE_DELAY_MS. The rejected
+      // sub must NOT be re-issued.
+      socket.sentMessages.length = 0;
+      socket._triggerMessage(JSON.stringify(['AUTH', 'challenge-string']));
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const reissued = socket.sentMessages.find((m) => m.includes(`"REQ","${subId}"`));
+      expect(reissued).toBeUndefined();
+    });
+  });
+
+  describe('queryWithFirstSeenWins settles promptly on CLOSED', () => {
+    it('resolves null for queryPubkeyByNametag on CLOSED without waiting for query timeout', async () => {
+      // Use an overlong timeout so the test would visibly hang if the
+      // CLOSED-handling path were broken.
+      await connect({ queryTimeoutMs: 60000 });
+
+      // Kick off a nametag query.
+      const pending = client.queryPubkeyByNametag('alice');
+
+      // Find the auto-generated sub_id from the most recent REQ frame.
+      const reqMsg = socket.sentMessages
+        .map((m) => JSON.parse(m))
+        .find((m) => m[0] === 'REQ' && typeof m[1] === 'string' && m[1].startsWith('sub_'));
+      expect(reqMsg).toBeDefined();
+      const subId: string = reqMsg[1];
+
+      // Relay rejects with CLOSED instead of EOSE.
+      socket._triggerMessage(
+        JSON.stringify(['CLOSED', subId, 'error: Maximum concurrent subscription count reached']),
+      );
+
+      // We MUST NOT have to wait the full 60s timeout. Advance a small
+      // amount and assert the promise resolves null.
+      await vi.advanceTimersByTimeAsync(10);
+      const result = await pending;
+      expect(result).toBeNull();
+    });
+
+    it('still resolves null normally on EOSE with zero events', async () => {
+      await connect({ queryTimeoutMs: 60000 });
+
+      const pending = client.queryPubkeyByNametag('alice');
+      const reqMsg = socket.sentMessages
+        .map((m) => JSON.parse(m))
+        .find((m) => m[0] === 'REQ' && typeof m[1] === 'string' && m[1].startsWith('sub_'));
+      const subId: string = reqMsg[1];
+
+      socket._triggerMessage(JSON.stringify(['EOSE', subId]));
+      await vi.advanceTimersByTimeAsync(10);
+      expect(await pending).toBeNull();
+    });
+  });
+});

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -2,9 +2,13 @@
  * Unit tests for the relay-resilience fixes covered by issue #7:
  *   1. The keepalive "ping" REQ filter must be scoped to authors:[self] so
  *      the relay does not stream a global live-tail through it after EOSE.
- *   2. A CLOSED frame from the relay must remove the subscription from the
- *      client-local map, so reconnect-resubscribe and AUTH-resubscribe do
- *      not re-issue the rejected REQ.
+ *   2. A CLOSED frame from the relay must surface to the listener via
+ *      onError and be recorded on the *sending* relay's closedSubIds, so
+ *      resubscribeAll / post-AUTH resubscribe skip it on that relay only.
+ *      The global subscriptions map is intentionally NOT modified —
+ *      multi-relay clients may still have the same sub_id alive on a
+ *      healthy relay; listener-driven unsubscribe() is what cleans the
+ *      global entry across all relays.
  *   3. queryWithFirstSeenWins (used by queryPubkeyByNametag /
  *      queryBindingByNametag / queryBindingByAddress) must settle promptly
  *      on a CLOSED frame instead of waiting for the full query timeout —
@@ -115,6 +119,24 @@ describe('Relay resilience fixes (issue #7)', () => {
   });
 
   describe('CLOSED frame handling', () => {
+    it('accepts truncated ["CLOSED", subId] frames with a default reason', async () => {
+      // NIP-01 makes the message field optional. The handler must
+      // notify the listener AND mark the sub closed on the sending
+      // relay even when the reason is missing — otherwise queries
+      // hang to timeout and resubscribe loops persist.
+      await connect();
+
+      const onError = vi.fn();
+      const subId = client.subscribe(Filter.builder().kinds(1).build(), {
+        onEvent: vi.fn(),
+        onError,
+      });
+
+      socket._triggerMessage(JSON.stringify(['CLOSED', subId])); // no reason
+
+      expect(onError).toHaveBeenCalledWith(subId, expect.stringContaining('no reason provided'));
+    });
+
     it('notifies the listener via onError and marks the sub closed on the sending relay', async () => {
       await connect();
 

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -114,11 +114,17 @@ describe('Relay resilience fixes (issue #7)', () => {
       mockCreateWebSocket.mockImplementation(() => pendingSocketPromise);
 
       socket = createFakeSocket();
-      const connectPromise = client.connect('wss://slow.test');
+      // Pre-attach a handler so the rejection that fires during
+      // `advanceTimersByTimeAsync` is observed immediately and
+      // doesn't briefly count as an "unhandled rejection" — Node
+      // (and CI) will fail the run otherwise.
+      const connectError = client.connect('wss://slow.test').catch((e) => e);
 
       // Advance past the connection timeout (30s default).
       await vi.advanceTimersByTimeAsync(31_000);
-      await expect(connectPromise).rejects.toThrow(/timed out/);
+      const err = await connectError;
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/timed out/);
 
       // NOW the socket arrives. The .then guard must close it and
       // skip registration.
@@ -140,13 +146,16 @@ describe('Relay resilience fixes (issue #7)', () => {
       socket = createFakeSocket();
       mockCreateWebSocket.mockResolvedValue(socket);
 
-      const connectPromise = client.connect('wss://slow.test');
+      // Pre-attach handler — see comment in the previous test.
+      const connectError = client.connect('wss://slow.test').catch((e) => e);
       // Resolve createWebSocket but DON'T trigger onopen yet.
       await vi.advanceTimersByTimeAsync(0);
       // Advance past the connection timeout — outer promise rejects,
       // and the timeout closes the still-pending socket.
       await vi.advanceTimersByTimeAsync(31_000);
-      await expect(connectPromise).rejects.toThrow(/timed out/);
+      const err = await connectError;
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/timed out/);
 
       // Even if the socket somehow fires onopen later (e.g., the
       // timeout's close() didn't take effect), the onopen guard

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -559,6 +559,36 @@ describe('Relay resilience fixes (issue #7)', () => {
       expect(result).toBeNull(); // no events delivered
     });
 
+    it('subscribe() rejects reserved __nostr-sdk- sub_ids', async () => {
+      // Keep user code from accidentally colliding with the
+      // keepalive timer's reserved sub_id (PING_SUB_ID).
+      await connect();
+      expect(() => client.subscribe('__nostr-sdk-keepalive__', Filter.builder().kinds(1).build(), {
+        onEvent: vi.fn(),
+      })).toThrow(/reserved.*__nostr-sdk-/);
+      // Other namespaces are fine.
+      expect(() => client.subscribe('my-app-sub', Filter.builder().kinds(1).build(), {
+        onEvent: vi.fn(),
+      })).not.toThrow();
+    });
+
+    it('relay-disconnect onError includes the relay URL (multi-relay attribution)', async () => {
+      // In a multi-relay client a bare "Relay disconnected: ..."
+      // message doesn't tell the listener which relay dropped.
+      // The URL must be in the message.
+      await connect();
+      const onError = vi.fn();
+      client.subscribe(Filter.builder().kinds(1).build(), {
+        onEvent: vi.fn(),
+        onError,
+      });
+      socket._triggerClose(1006, 'eof');
+      expect(onError).toHaveBeenCalled();
+      const arg = onError.mock.calls[0][1] as string;
+      expect(arg).toContain('Relay disconnected');
+      expect(arg).toContain('wss://relay.test');
+    });
+
     it('relay disconnect mid-query triggers a re-check (no timeout wait)', async () => {
       // Self-audit invariant + Copilot review: queryWithFirstSeenWins
       // only re-evaluates allRelaysDoneFor when a listener callback

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -292,22 +292,18 @@ describe('Relay resilience fixes (issue #7)', () => {
       expect(reqs[1][2].kinds).toEqual([2]);
     });
 
-    it('clears BOTH closedSubIds and eosedSubIds before post-AUTH resubscribe', async () => {
-      // Self-audit invariant: pre-auth a relay may have either CLOSED
-      // (auth-required) or EOSE'd (returned 0 stored events because
-      // the filter was unsatisfiable without auth context) any
-      // active sub. Post-auth, BOTH markers must be cleared so the
-      // resubscribed REQ doesn't see a stale "done" state and so
-      // any in-flight queryWithFirstSeenWins re-checks
-      // allRelaysDoneFor against fresh state.
+    it('post-AUTH resubscribe clears eosedSubIds (re-arms stale-EOSE state)', async () => {
+      // Pre-auth a relay may have EOSE'd a sub with 0 stored events
+      // because the filter was unsatisfiable without auth context.
+      // Post-auth that's no longer true — the resubscribed REQ
+      // might match. We MUST re-arm the local "still waiting" state
+      // so any in-flight queryWithFirstSeenWins doesn't see this
+      // relay as already-done from a stale eosedSubIds marker.
       await connect();
       const subId = client.subscribe(Filter.builder().kinds(1).build(), { onEvent: vi.fn() });
 
-      // Relay marks the sub eosed (pre-auth empty result).
       socket._triggerMessage(JSON.stringify(['EOSE', subId]));
 
-      // AUTH challenge → SDK signs and replies, then schedules
-      // resubscribeAll after AUTH_RESUBSCRIBE_DELAY_MS.
       socket.sentMessages.length = 0;
       socket._triggerMessage(JSON.stringify(['AUTH', 'challenge-string']));
       await vi.advanceTimersByTimeAsync(5000);
@@ -315,6 +311,31 @@ describe('Relay resilience fixes (issue #7)', () => {
       // Post-AUTH: the previously-EOSE'd sub MUST be re-issued.
       const reissued = socket.sentMessages.find((m) => m.includes(`"REQ","${subId}"`));
       expect(reissued).toBeDefined();
+    });
+
+    it('post-AUTH resubscribe SKIPS terminally-rejected subs (rate-limit stays blocked)', async () => {
+      // Counterpart invariant. closedSubIds populated by terminal
+      // rejections (rate-limited, blocked, etc.) MUST persist across
+      // AUTH success — AUTH doesn't relax those rejections, and
+      // re-issuing them would just trigger the same rejection in a
+      // loop. Auth-required CLOSEDs aren't in this set in the first
+      // place (handleClosedMessage skips them as transient).
+      await connect();
+      const goodSubId = client.subscribe(Filter.builder().kinds(1).build(), { onEvent: vi.fn() });
+      const badSubId = client.subscribe(Filter.builder().kinds(2).build(), { onEvent: vi.fn() });
+
+      // Terminal rejection lands in closedSubIds.
+      socket._triggerMessage(JSON.stringify(['CLOSED', badSubId, 'rate-limited: too many']));
+
+      socket.sentMessages.length = 0;
+      socket._triggerMessage(JSON.stringify(['AUTH', 'challenge-string']));
+      await vi.advanceTimersByTimeAsync(5000);
+
+      // Post-AUTH: goodSubId IS re-issued; badSubId is NOT.
+      const goodReissued = socket.sentMessages.find((m) => m.includes(`"REQ","${goodSubId}"`));
+      const badReissued = socket.sentMessages.find((m) => m.includes(`"REQ","${badSubId}"`));
+      expect(goodReissued).toBeDefined();
+      expect(badReissued).toBeUndefined();
     });
 
     it('accepts truncated ["CLOSED", subId] frames with a default reason', async () => {

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -1,7 +1,9 @@
 /**
  * Unit tests for the relay-resilience fixes covered by issue #7:
- *   1. The keepalive "ping" REQ filter must be scoped to authors:[self] so
- *      the relay does not stream a global live-tail through it after EOSE.
+ *   1. The keepalive "ping" REQ filter must use a constraint no real
+ *      event can match, so neither the initial query nor the post-EOSE
+ *      live tail returns wallet events. (Earlier `authors:[self]`
+ *      scoping echoed every event the wallet itself published.)
  *   2. A CLOSED frame from the relay must surface to the listener via
  *      onError and be recorded on the *sending* relay's closedSubIds, so
  *      resubscribeAll / post-AUTH resubscribe skip it on that relay only.
@@ -190,7 +192,7 @@ describe('Relay resilience fixes (issue #7)', () => {
   });
 
   describe('ping filter scoping', () => {
-    it('scopes the keepalive REQ to authors:[selfPubkey]', async () => {
+    it('keepalive REQ filter cannot match any real event (no live-tail leak)', async () => {
       await connect({ pingIntervalMs: 15000 });
 
       await vi.advanceTimersByTimeAsync(15000);
@@ -199,10 +201,36 @@ describe('Relay resilience fixes (issue #7)', () => {
         .find((m) => m[0] === 'REQ' && m[1] === '__nostr-sdk-keepalive__');
 
       expect(reqFrame).toBeDefined();
-      expect(reqFrame[2]).toEqual({
-        authors: [keyManager.getPublicKeyHex()],
-        limit: 1,
-      });
+      const filter = reqFrame[2];
+
+      // The filter must NOT include `authors:[self]` (or any other
+      // open-ended constraint) — that's exactly the live-tail leak that
+      // echoed the wallet's own kind-31113 events back on the keepalive
+      // sub. The fix scopes by an unreachable event id.
+      expect(filter.authors).toBeUndefined();
+
+      // Required: the filter constrains by `ids:[<all-zero hash>]`.
+      // Real Nostr ids are SHA-256 hashes; the all-zero hash is
+      // unreachable, so EOSE comes back immediately and the live tail
+      // never matches a future event.
+      expect(filter.ids).toEqual(['0'.repeat(64)]);
+      expect(filter.limit).toBe(1);
+    });
+
+    it('keepalive filter does not match the wallet\'s own pubkey', async () => {
+      await connect({ pingIntervalMs: 15000 });
+
+      await vi.advanceTimersByTimeAsync(15000);
+      const reqFrame = socket.sentMessages
+        .map((m) => JSON.parse(m))
+        .find((m) => m[0] === 'REQ' && m[1] === '__nostr-sdk-keepalive__');
+
+      // Behavioral assertion: nothing in the filter references the
+      // wallet's own pubkey. If a real event from this pubkey arrived
+      // on the WS, the relay's filter logic would not match this sub.
+      const selfPk = keyManager.getPublicKeyHex();
+      const serialised = JSON.stringify(reqFrame);
+      expect(serialised).not.toContain(selfPk);
     });
 
     it('precedes the REQ with a CLOSE for the same sub_id (no slot accumulation)', async () => {

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -174,7 +174,7 @@ describe('Relay resilience fixes (issue #7)', () => {
       await vi.advanceTimersByTimeAsync(15000);
       const reqFrame = socket.sentMessages
         .map((m) => JSON.parse(m))
-        .find((m) => m[0] === 'REQ' && m[1] === 'ping');
+        .find((m) => m[0] === 'REQ' && m[1] === '__nostr-sdk-keepalive__');
 
       expect(reqFrame).toBeDefined();
       expect(reqFrame[2]).toEqual({
@@ -189,7 +189,7 @@ describe('Relay resilience fixes (issue #7)', () => {
       await vi.advanceTimersByTimeAsync(15000);
       const pingFrames = socket.sentMessages
         .map((m) => JSON.parse(m))
-        .filter((m) => m[1] === 'ping');
+        .filter((m) => m[1] === '__nostr-sdk-keepalive__');
 
       expect(pingFrames.length).toBe(2);
       expect(pingFrames[0][0]).toBe('CLOSE');

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -168,7 +168,14 @@ describe('Relay resilience fixes (issue #7)', () => {
       expect(onEvent).not.toHaveBeenCalled();
     });
 
-    it('does NOT replay a CLOSED-rejected sub on simulated post-AUTH resubscribe', async () => {
+    it('post-AUTH resubscribe RE-ISSUES previously CLOSED-rejected subs (NIP-42 auth-required)', async () => {
+      // NIP-42 flow: relay sends CLOSED("auth-required") for any
+      // pre-auth REQ, then on AUTH success the client must re-issue
+      // those REQs. The closedSubIds bookkeeping must NOT permanently
+      // skip them; it must be cleared in the post-AUTH resubscribe
+      // path. (The "regular" resubscribeAll on reconnect operates on
+      // a fresh socket with a fresh closedSubIds set, so that path is
+      // already covered by RelayConnection construction.)
       await connect();
 
       const subId = client.subscribe(Filter.builder().kinds(1).build(), {
@@ -179,20 +186,21 @@ describe('Relay resilience fixes (issue #7)', () => {
       // Initial REQ went out.
       expect(socket.sentMessages).toContain(reqFrame);
 
-      // Relay rejects.
-      socket._triggerMessage(JSON.stringify(['CLOSED', subId, 'error: auth-required']));
+      // Relay rejects pre-auth.
+      socket._triggerMessage(JSON.stringify(['CLOSED', subId, 'auth-required: please authenticate']));
 
-      // Simulate post-AUTH resubscribe by triggering an AUTH challenge —
-      // resubscribeAll runs after AUTH_RESUBSCRIBE_DELAY_MS. The rejected
-      // sub must NOT be re-issued *on this relay* (other healthy relays
-      // would still resubscribe it; that's covered by the per-relay
-      // closedSubIds tracking).
       socket.sentMessages.length = 0;
+
+      // AUTH challenge fires; the SDK signs and replies, then schedules
+      // resubscribeAll after AUTH_RESUBSCRIBE_DELAY_MS.
       socket._triggerMessage(JSON.stringify(['AUTH', 'challenge-string']));
       await vi.advanceTimersByTimeAsync(5000);
 
+      // The previously-rejected sub MUST be re-issued on this relay so
+      // post-auth flow can succeed. (Other healthy relays were never
+      // in the rejected state to begin with.)
       const reissued = socket.sentMessages.find((m) => m.includes(`"REQ","${subId}"`));
-      expect(reissued).toBeUndefined();
+      expect(reissued).toBeDefined();
     });
   });
 

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -451,6 +451,49 @@ describe('Relay resilience fixes (issue #7)', () => {
       expect(Date.now() - start).toBeLessThan(1000);
     });
 
+    it('does NOT settle on auth-required CLOSED — leaves the sub in the global Map for post-AUTH retry', async () => {
+      // NIP-42 transient case. Pre-auth relays typically reject REQs
+      // with `CLOSED("auth-required:...")` then immediately send an
+      // AUTH challenge. resubscribeAfterAuth re-issues the sub —
+      // but if we mark closedSubIds and the query settles + calls
+      // unsubscribe, the sub is gone from the global Map by the
+      // time resubscribe runs, and the query is permanently lost.
+      // The fix: skip adding to closedSubIds for auth-required
+      // rejections; listener still notified, but no settle.
+      await connect({ queryTimeoutMs: 60_000 });
+
+      const pending = client.queryPubkeyByNametag('alice');
+      const reqMsg = socket.sentMessages
+        .map((m) => JSON.parse(m))
+        .find((m) => m[0] === 'REQ' && typeof m[1] === 'string' && m[1].startsWith('sub_'));
+      const subId: string = reqMsg[1];
+
+      // Relay rejects pre-auth.
+      socket._triggerMessage(JSON.stringify(['CLOSED', subId, 'auth-required: please authenticate']));
+      await vi.advanceTimersByTimeAsync(10);
+
+      // Promise must NOT have settled — auth retry might still
+      // produce events.
+      let settled = false;
+      pending.then(() => { settled = true; });
+      await vi.advanceTimersByTimeAsync(10);
+      expect(settled).toBe(false);
+
+      // The sub MUST still be registered in the global Map so that
+      // resubscribeAfterAuth can find it and re-issue the REQ.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const subs: Map<string, unknown> = (client as any).subscriptions;
+      expect(subs.has(subId)).toBe(true);
+
+      // Now the relay sends AUTH challenge → SDK signs and replies →
+      // resubscribeAfterAuth fires after the delay → REQ re-issued.
+      socket.sentMessages.length = 0;
+      socket._triggerMessage(JSON.stringify(['AUTH', 'challenge-string']));
+      await vi.advanceTimersByTimeAsync(5000);
+      const reissued = socket.sentMessages.find((m) => m.includes(`"REQ","${subId}"`));
+      expect(reissued).toBeDefined();
+    });
+
     it('settles on first CLOSED when only one relay is connected (single-relay back-compat)', async () => {
       // The new "wait for all" rule degenerates to "wait for the only
       // one" with a single relay, so single-relay clients see no

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -115,39 +115,57 @@ describe('Relay resilience fixes (issue #7)', () => {
   });
 
   describe('CLOSED frame handling', () => {
-    it('removes the subscription from the client-local map on CLOSED', async () => {
+    it('notifies the listener via onError and marks the sub closed on the sending relay', async () => {
       await connect();
 
       const onError = vi.fn();
+      const onEvent = vi.fn();
       const subId = client.subscribe(Filter.builder().kinds(1).build(), {
-        onEvent: vi.fn(),
+        onEvent,
         onError,
       });
 
-      // Verify the REQ was sent.
+      // The REQ was sent.
       expect(socket.sentMessages.some((m) => m.includes(`"REQ","${subId}"`))).toBe(true);
 
-      // Relay rejects with CLOSED (this is what nostr-rs-relay emits when
+      // Relay rejects with CLOSED (what nostr-rs-relay emits when
       // max_subscriptions is hit).
       socket._triggerMessage(JSON.stringify(['CLOSED', subId, 'error: rate-limited: too many concurrent REQs']));
 
-      // The listener is notified.
+      // Listener is notified with the relay's reason.
       expect(onError).toHaveBeenCalledWith(subId, expect.stringContaining('rate-limited'));
 
-      // The Map entry is gone — proven by the fact that a follow-up
-      // EVENT for that sub_id is silently dropped (no listener invocation).
-      // We verify by sending an EVENT and asserting onError isn't called
-      // a second time (the original onEvent handler also wouldn't fire,
-      // but easier to assert what *didn't* happen via call counts).
-      const onEventLater = vi.fn();
-      // Re-subscribe with the same sub_id to prove the slot was freed in
-      // the local map; subscribe assigns a new auto-generated sub_id, so
-      // we're really testing that `subscriptions.has(oldSubId)` is false.
-      client.unsubscribe(subId);   // should be a no-op now — no CLOSE frame emitted
-      const sentBefore = socket.sentMessages.length;
-      client.unsubscribe(subId);
-      expect(socket.sentMessages.length).toBe(sentBefore);
-      expect(onEventLater).not.toHaveBeenCalled();
+      // The sub_id is recorded on the relay's closedSubIds set so that
+      // reconnect / post-AUTH resubscribe skip it. We assert via the
+      // observable behavior in the next two tests rather than reaching
+      // into private state here.
+    });
+
+    it('drops EVENT frames after CLOSED in single-relay setup (no listener invocations)', async () => {
+      // Single-relay clients are the common case in the wild. With the
+      // sub still in the global map (so multi-relay tails keep working),
+      // we still need to make sure that an unsubscribe() called by the
+      // listener via onError actually empties the map — otherwise stale
+      // events keep arriving.
+      await connect();
+
+      const onError = vi.fn((subId: string) => client.unsubscribe(subId));
+      const onEvent = vi.fn();
+      const subId = client.subscribe(Filter.builder().kinds(1).build(), {
+        onEvent,
+        onError,
+      });
+
+      socket._triggerMessage(JSON.stringify(['CLOSED', subId, 'error: rate-limited']));
+      expect(onError).toHaveBeenCalledTimes(1);
+
+      // After the listener-driven unsubscribe(), a follow-up EVENT for
+      // the same sub_id must NOT fire onEvent.
+      socket._triggerMessage(JSON.stringify(['EVENT', subId, {
+        id: 'a'.repeat(64), pubkey: 'b'.repeat(64), created_at: 0, kind: 1,
+        tags: [], content: '', sig: 'c'.repeat(128),
+      }]));
+      expect(onEvent).not.toHaveBeenCalled();
     });
 
     it('does NOT replay a CLOSED-rejected sub on simulated post-AUTH resubscribe', async () => {
@@ -166,7 +184,9 @@ describe('Relay resilience fixes (issue #7)', () => {
 
       // Simulate post-AUTH resubscribe by triggering an AUTH challenge —
       // resubscribeAll runs after AUTH_RESUBSCRIBE_DELAY_MS. The rejected
-      // sub must NOT be re-issued.
+      // sub must NOT be re-issued *on this relay* (other healthy relays
+      // would still resubscribe it; that's covered by the per-relay
+      // closedSubIds tracking).
       socket.sentMessages.length = 0;
       socket._triggerMessage(JSON.stringify(['AUTH', 'challenge-string']));
       await vi.advanceTimersByTimeAsync(5000);

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -138,6 +138,28 @@ describe('Relay resilience fixes (issue #7)', () => {
       expect(relays.has('wss://slow.test')).toBe(false);
     });
 
+    it('rejects the connect promise immediately on handshake close (no 30s wait)', async () => {
+      // If the WebSocket closes BEFORE onopen fires (TCP handshake
+      // failure, immediate WS reject during upgrade, etc.), the
+      // outer connectToRelay promise was previously left pending
+      // until CONNECTION_TIMEOUT_MS expired (30s). Now socket.onclose
+      // detects "never connected" and rejects promptly.
+      client = new NostrClient(keyManager, { pingIntervalMs: 0 });
+      socket = createFakeSocket();
+      mockCreateWebSocket.mockResolvedValue(socket);
+
+      const connectError = client.connect('wss://broken.test').catch((e) => e);
+      // Let createWebSocket resolve and handlers attach.
+      await vi.advanceTimersByTimeAsync(0);
+      // Simulate handshake failure — close fires before onopen.
+      socket._triggerClose(1006, 'tcp reset');
+
+      // Must reject promptly, NOT wait the 30s connection timeout.
+      const err = await connectError;
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/closed during handshake/);
+    });
+
     it('discards a socket whose onopen fires AFTER the timeout (defense in depth)', async () => {
       // Even if createWebSocket resolves before the timeout, onopen
       // can fire after — same orphan-relay concern. The onopen

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -307,4 +307,69 @@ describe('Relay resilience fixes (issue #7)', () => {
       expect(await pending).toBeNull();
     });
   });
+
+  describe('multi-relay query: settle only when all relays are done', () => {
+    it('does NOT settle on first EOSE when a second relay is still streaming', async () => {
+      // Two fake sockets — one fast EOSE, one slow with matching events.
+      const socketA = createFakeSocket();
+      const socketB = createFakeSocket();
+      mockCreateWebSocket.mockResolvedValueOnce(socketA);
+      mockCreateWebSocket.mockResolvedValueOnce(socketB);
+
+      client = new NostrClient(keyManager, {
+        pingIntervalMs: 0,
+        queryTimeoutMs: 60_000,
+      });
+      const cp = Promise.all([
+        client.connect('wss://a.test'),
+        client.connect('wss://b.test'),
+      ]);
+      await vi.advanceTimersByTimeAsync(0);
+      socketA._triggerOpen();
+      socketB._triggerOpen();
+      await cp;
+
+      const pending = client.queryPubkeyByNametag('alice');
+
+      // Find the sub_id from socketA's REQ frame (both got the same id).
+      const reqA = socketA.sentMessages
+        .map((m) => JSON.parse(m))
+        .find((m) => m[0] === 'REQ' && typeof m[1] === 'string' && m[1].startsWith('sub_'));
+      const subId: string = reqA[1];
+
+      // Relay A finishes immediately with no events.
+      socketA._triggerMessage(JSON.stringify(['EOSE', subId]));
+      await vi.advanceTimersByTimeAsync(10);
+      // Promise must NOT resolve yet — relay B hasn't reported.
+      let settled = false;
+      pending.then(() => { settled = true; });
+      await vi.advanceTimersByTimeAsync(10);
+      expect(settled).toBe(false);
+
+      // Relay B then delivers a matching event followed by EOSE.
+      // We need a real signed event for verify() to pass; for this
+      // test we just need the future to settle on EOSE — events
+      // missing valid signatures are dropped silently.
+      socketB._triggerMessage(JSON.stringify(['EOSE', subId]));
+      await vi.advanceTimersByTimeAsync(10);
+      // Now both relays are done → settle.
+      const result = await pending;
+      expect(result).toBeNull(); // no events delivered
+    });
+
+    it('settles on first CLOSED when only one relay is connected (single-relay back-compat)', async () => {
+      // The new "wait for all" rule degenerates to "wait for the only
+      // one" with a single relay, so single-relay clients see no
+      // behavior change.
+      await connect({ queryTimeoutMs: 60_000 });
+      const pending = client.queryPubkeyByNametag('alice');
+      const reqMsg = socket.sentMessages
+        .map((m) => JSON.parse(m))
+        .find((m) => m[0] === 'REQ' && typeof m[1] === 'string' && m[1].startsWith('sub_'));
+      const subId: string = reqMsg[1];
+      socket._triggerMessage(JSON.stringify(['CLOSED', subId, 'rate-limited']));
+      await vi.advanceTimersByTimeAsync(10);
+      expect(await pending).toBeNull();
+    });
+  });
 });

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -206,24 +206,36 @@ describe('Relay resilience fixes (issue #7)', () => {
       // we might use later.
       await connect();
 
-      // Simulate the relay sending CLOSED for a sub we never
-      // registered. The handler must drop it silently — listener for
-      // a different (real) sub stays untouched, and a follow-up
-      // legitimate subscribe with that ID must work normally.
+      // Register a real subscription FIRST so onError is wired to
+      // something. Then inject a CLOSED for an unrelated, never-
+      // registered sub_id. The guard must drop the ghost frame
+      // silently — listener for the real sub must NOT be notified
+      // (a previous version of this test created the listener
+      // unattached, so the assertion was vacuous).
       const onError = vi.fn();
-      socket._triggerMessage(JSON.stringify(['CLOSED', 'ghost-sub', 'error: rejected']));
-      expect(onError).not.toHaveBeenCalled();
-
-      // Subsequent legitimate subscribe with that same id is unaffected
-      // (the ID was never blocked).
-      const subId = client.subscribe(Filter.builder().kinds(1).build(), {
+      const realSubId = client.subscribe(Filter.builder().kinds(1).build(), {
         onEvent: vi.fn(),
         onError,
       });
-      // Now CLOSED with the real sub_id IS surfaced.
-      socket._triggerMessage(JSON.stringify(['CLOSED', subId, 'real-rejection']));
+
+      // Ghost CLOSED for a sub the client never knows about.
+      socket._triggerMessage(JSON.stringify(['CLOSED', 'ghost-sub', 'error: rejected']));
+      expect(onError).not.toHaveBeenCalled();
+
+      // CLOSED with the real sub_id IS surfaced.
+      socket._triggerMessage(JSON.stringify(['CLOSED', realSubId, 'real-rejection']));
       expect(onError).toHaveBeenCalledTimes(1);
-      expect(onError).toHaveBeenCalledWith(subId, expect.stringContaining('real-rejection'));
+      expect(onError).toHaveBeenCalledWith(realSubId, expect.stringContaining('real-rejection'));
+
+      // And: re-subscribing with the formerly-ghost sub_id must
+      // work normally (the ID was never blocked in any closedSubIds).
+      const onError2 = vi.fn();
+      client.subscribe('ghost-sub', Filter.builder().kinds(2).build(), {
+        onEvent: vi.fn(),
+        onError: onError2,
+      });
+      socket._triggerMessage(JSON.stringify(['CLOSED', 'ghost-sub', 'now-real']));
+      expect(onError2).toHaveBeenCalledTimes(1);
     });
 
     it('also ignores CLOSED frames where sub_id is non-string (defensive)', async () => {

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -38,6 +38,7 @@ const mockCreateWebSocket = vi.mocked(createWebSocket);
 function createFakeSocket(): IWebSocket & {
   _triggerOpen(): void;
   _triggerMessage(data: string): void;
+  _triggerClose(code?: number, reason?: string): void;
   sentMessages: string[];
   _readyState: number;
 } {
@@ -50,10 +51,17 @@ function createFakeSocket(): IWebSocket & {
     onerror: null,
     sentMessages: [],
     send(data: string) { this.sentMessages.push(data); },
-    close() { this._readyState = CLOSED; },
+    close(code?: number, reason?: string) {
+      this._readyState = CLOSED;
+      if (this.onclose) this.onclose({ code: code ?? 1000, reason: reason ?? '' });
+    },
     _triggerOpen() { if (this.onopen) this.onopen({}); },
     _triggerMessage(data: string) {
       if (this.onmessage) this.onmessage({ data } as WebSocketMessageEvent);
+    },
+    _triggerClose(code = 1006, reason = '') {
+      this._readyState = CLOSED;
+      if (this.onclose) this.onclose({ code, reason });
     },
   };
   return socket;
@@ -87,6 +95,68 @@ describe('Relay resilience fixes (issue #7)', () => {
     await p;
     socket.sentMessages.length = 0;
   }
+
+  describe('connection-timeout race', () => {
+    it('discards a socket that arrives AFTER the connection timeout (no orphan relay)', async () => {
+      // Self-audit + Copilot review: createWebSocket can resolve
+      // after CONNECTION_TIMEOUT_MS has fired and the outer promise
+      // has rejected. Without the fix, the late-arriving socket
+      // would still register in this.relays, start a pingTimer,
+      // resubscribeAll, etc. — orphan resources the caller can't
+      // see (their connect() saw a rejection).
+      client = new NostrClient(keyManager, { pingIntervalMs: 0 });
+
+      // Pin the socket creation so it never resolves until we say.
+      let socketResolver!: (s: typeof socket) => void;
+      const pendingSocketPromise = new Promise<typeof socket>((res) => {
+        socketResolver = res;
+      });
+      mockCreateWebSocket.mockImplementation(() => pendingSocketPromise);
+
+      socket = createFakeSocket();
+      const connectPromise = client.connect('wss://slow.test');
+
+      // Advance past the connection timeout (30s default).
+      await vi.advanceTimersByTimeAsync(31_000);
+      await expect(connectPromise).rejects.toThrow(/timed out/);
+
+      // NOW the socket arrives. The .then guard must close it and
+      // skip registration.
+      socketResolver(socket);
+      await vi.advanceTimersByTimeAsync(0);
+      // The fake socket records close() calls via state; we assert
+      // it's CLOSED and that no relay was registered for the URL.
+      expect(socket._readyState).toBe(CLOSED);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const relays: Map<string, unknown> = (client as any).relays;
+      expect(relays.has('wss://slow.test')).toBe(false);
+    });
+
+    it('discards a socket whose onopen fires AFTER the timeout (defense in depth)', async () => {
+      // Even if createWebSocket resolves before the timeout, onopen
+      // can fire after — same orphan-relay concern. The onopen
+      // handler must check the timedOut flag too.
+      client = new NostrClient(keyManager, { pingIntervalMs: 0 });
+      socket = createFakeSocket();
+      mockCreateWebSocket.mockResolvedValue(socket);
+
+      const connectPromise = client.connect('wss://slow.test');
+      // Resolve createWebSocket but DON'T trigger onopen yet.
+      await vi.advanceTimersByTimeAsync(0);
+      // Advance past the connection timeout — outer promise rejects,
+      // and the timeout closes the still-pending socket.
+      await vi.advanceTimersByTimeAsync(31_000);
+      await expect(connectPromise).rejects.toThrow(/timed out/);
+
+      // Even if the socket somehow fires onopen later (e.g., the
+      // timeout's close() didn't take effect), the onopen guard
+      // must skip the registration.
+      socket._triggerOpen();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const relays: Map<string, unknown> = (client as any).relays;
+      expect(relays.has('wss://slow.test')).toBe(false);
+    });
+  });
 
   describe('ping filter scoping', () => {
     it('scopes the keepalive REQ to authors:[selfPubkey]', async () => {
@@ -423,6 +493,29 @@ describe('Relay resilience fixes (issue #7)', () => {
       // Now both relays are done → settle.
       const result = await pending;
       expect(result).toBeNull(); // no events delivered
+    });
+
+    it('relay disconnect mid-query triggers a re-check (no timeout wait)', async () => {
+      // Self-audit invariant + Copilot review: queryWithFirstSeenWins
+      // only re-evaluates allRelaysDoneFor when a listener callback
+      // (EOSE / CLOSED → onError) fires. If a relay drops the
+      // WebSocket without sending either, the query would otherwise
+      // hang until queryTimeoutMs even though the disconnected relay
+      // no longer counts toward pending relays. Fix: socket.onclose
+      // synthetically fires onError on every active sub.
+      await connect({ queryTimeoutMs: 60_000 });
+      const pending = client.queryPubkeyByNametag('alice');
+      // Verify the REQ went out so we know we're truly mid-query.
+      expect(socket.sentMessages.some((m) => m.includes('"REQ","sub_'))).toBe(true);
+
+      // Drop the socket without any EOSE/CLOSED — simulates a
+      // network blip. Without the fix, the query hangs to the 60s
+      // timeout. With the fix, onclose fires synthetic onError →
+      // listener re-checks allRelaysDoneFor → 0 connected → settle.
+      socket._triggerClose(1006, 'Network error');
+
+      const result = await pending;
+      expect(result).toBeNull();
     });
 
     it('disconnect() settles in-flight queries immediately (no full timeout wait)', async () => {

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -158,6 +158,74 @@ describe('Relay resilience fixes (issue #7)', () => {
       expect(onError).not.toHaveBeenCalled();
     });
 
+    it('handleEventMessage drops EVENT frames with non-string sub_id (DoS guard)', async () => {
+      await connect();
+      const onEvent = vi.fn();
+      client.subscribe(Filter.builder().kinds(1).build(), { onEvent });
+      // Numeric sub_id — must be silently dropped.
+      socket._triggerMessage(JSON.stringify(['EVENT', 42, {
+        id: 'a'.repeat(64), pubkey: 'b'.repeat(64), created_at: 0, kind: 1,
+        tags: [], content: '', sig: 'c'.repeat(128),
+      }]));
+      // Object sub_id.
+      socket._triggerMessage(JSON.stringify(['EVENT', { x: 1 }, {
+        id: 'a'.repeat(64), pubkey: 'b'.repeat(64), created_at: 0, kind: 1,
+        tags: [], content: '', sig: 'c'.repeat(128),
+      }]));
+      expect(onEvent).not.toHaveBeenCalled();
+    });
+
+    it('subscribe() wipes stale per-relay EOSE/CLOSED markers for the same sub_id', async () => {
+      // Self-audit invariant: a fresh subscribe with a sub_id that was
+      // previously CLOSED on some relay must NOT be skipped on that
+      // relay. Same for stale EOSE markers — otherwise the new sub
+      // would be treated as already-done and queries built on top of
+      // it would settle prematurely.
+      await connect();
+
+      // Subscribe + relay sends CLOSED → marker set.
+      const subId = 'reused-sub';
+      client.subscribe(subId, Filter.builder().kinds(1).build(), { onEvent: vi.fn() });
+      socket._triggerMessage(JSON.stringify(['CLOSED', subId, 'rate-limited']));
+      // Now subscribe again with the same id (fresh listener).
+      client.subscribe(subId, Filter.builder().kinds(2).build(), { onEvent: vi.fn() });
+
+      // The second subscribe must have sent a fresh REQ — even though
+      // the relay had marked the prior one closed.
+      const reqs = socket.sentMessages
+        .map((m) => JSON.parse(m))
+        .filter((m) => m[0] === 'REQ' && m[1] === subId);
+      expect(reqs.length).toBe(2);
+      // And the second REQ uses the new filter (kinds:[2]), not the
+      // old one — proving it's a real re-subscribe.
+      expect(reqs[1][2].kinds).toEqual([2]);
+    });
+
+    it('clears BOTH closedSubIds and eosedSubIds before post-AUTH resubscribe', async () => {
+      // Self-audit invariant: pre-auth a relay may have either CLOSED
+      // (auth-required) or EOSE'd (returned 0 stored events because
+      // the filter was unsatisfiable without auth context) any
+      // active sub. Post-auth, BOTH markers must be cleared so the
+      // resubscribed REQ doesn't see a stale "done" state and so
+      // any in-flight queryWithFirstSeenWins re-checks
+      // allRelaysDoneFor against fresh state.
+      await connect();
+      const subId = client.subscribe(Filter.builder().kinds(1).build(), { onEvent: vi.fn() });
+
+      // Relay marks the sub eosed (pre-auth empty result).
+      socket._triggerMessage(JSON.stringify(['EOSE', subId]));
+
+      // AUTH challenge → SDK signs and replies, then schedules
+      // resubscribeAll after AUTH_RESUBSCRIBE_DELAY_MS.
+      socket.sentMessages.length = 0;
+      socket._triggerMessage(JSON.stringify(['AUTH', 'challenge-string']));
+      await vi.advanceTimersByTimeAsync(5000);
+
+      // Post-AUTH: the previously-EOSE'd sub MUST be re-issued.
+      const reissued = socket.sentMessages.find((m) => m.includes(`"REQ","${subId}"`));
+      expect(reissued).toBeDefined();
+    });
+
     it('accepts truncated ["CLOSED", subId] frames with a default reason', async () => {
       // NIP-01 makes the message field optional. The handler must
       // notify the listener AND mark the sub closed on the sending
@@ -355,6 +423,32 @@ describe('Relay resilience fixes (issue #7)', () => {
       // Now both relays are done → settle.
       const result = await pending;
       expect(result).toBeNull(); // no events delivered
+    });
+
+    it('disconnect() settles in-flight queries immediately (no full timeout wait)', async () => {
+      // Self-audit found: prior to this fix, calling disconnect()
+      // mid-query left the future unresolved until queryTimeoutMs
+      // elapsed. Listeners weren't notified, so allRelaysDoneFor was
+      // never re-checked.
+      await connect({ queryTimeoutMs: 60_000 });
+      const pending = client.queryPubkeyByNametag('alice');
+      // Verify the REQ went out so we know we're truly mid-query.
+      const reqMsg = socket.sentMessages
+        .map((m) => JSON.parse(m))
+        .find((m) => m[0] === 'REQ' && typeof m[1] === 'string' && m[1].startsWith('sub_'));
+      expect(reqMsg).toBeDefined();
+
+      const start = Date.now();
+      client.disconnect();
+      // Microtask flush — listener fires synchronously inside disconnect.
+      const result = await pending;
+      // Must be null (no events delivered) and resolved promptly,
+      // not after the 60s timeout.
+      expect(result).toBeNull();
+      // Date.now() with fake timers stays at the same instant; what
+      // matters is the promise resolved, which it must have to reach
+      // this line.
+      expect(Date.now() - start).toBeLessThan(1000);
     });
 
     it('settles on first CLOSED when only one relay is connected (single-relay back-compat)', async () => {

--- a/tests/unit/relay-fixes.test.ts
+++ b/tests/unit/relay-fixes.test.ts
@@ -119,6 +119,45 @@ describe('Relay resilience fixes (issue #7)', () => {
   });
 
   describe('CLOSED frame handling', () => {
+    it('ignores CLOSED for unknown sub_ids (DoS guard)', async () => {
+      // A misbehaving or malicious relay can spam CLOSED frames for
+      // arbitrary sub_ids the client never subscribed to. Without a
+      // guard, those would each grow `closedSubIds` unbounded over a
+      // long-lived connection, and could pre-emptively block sub_ids
+      // we might use later.
+      await connect();
+
+      // Simulate the relay sending CLOSED for a sub we never
+      // registered. The handler must drop it silently — listener for
+      // a different (real) sub stays untouched, and a follow-up
+      // legitimate subscribe with that ID must work normally.
+      const onError = vi.fn();
+      socket._triggerMessage(JSON.stringify(['CLOSED', 'ghost-sub', 'error: rejected']));
+      expect(onError).not.toHaveBeenCalled();
+
+      // Subsequent legitimate subscribe with that same id is unaffected
+      // (the ID was never blocked).
+      const subId = client.subscribe(Filter.builder().kinds(1).build(), {
+        onEvent: vi.fn(),
+        onError,
+      });
+      // Now CLOSED with the real sub_id IS surfaced.
+      socket._triggerMessage(JSON.stringify(['CLOSED', subId, 'real-rejection']));
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(subId, expect.stringContaining('real-rejection'));
+    });
+
+    it('also ignores CLOSED frames where sub_id is non-string (defensive)', async () => {
+      await connect();
+      const onError = vi.fn();
+      client.subscribe(Filter.builder().kinds(1).build(), { onEvent: vi.fn(), onError });
+      // Malformed: numeric sub_id.
+      socket._triggerMessage(JSON.stringify(['CLOSED', 42, 'whatever']));
+      // Malformed: object sub_id.
+      socket._triggerMessage(JSON.stringify(['CLOSED', { x: 1 }, 'whatever']));
+      expect(onError).not.toHaveBeenCalled();
+    });
+
     it('accepts truncated ["CLOSED", subId] frames with a default reason', async () => {
       // NIP-01 makes the message field optional. The handler must
       // notify the listener AND mark the sub closed on the sending

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+// Separate config for integration tests — these hit live network endpoints
+// (Nostr relays) and are excluded from the default `vitest run`. Run with:
+//   npm run test:integration
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/integration/**/*.test.ts'],
+    testTimeout: 60_000,
+    hookTimeout: 30_000,
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
Fixes #7.

Three composing defects in `NostrClient` combine to silently fail nametag resolution against busy relays under load. Sphere users see this as `Cannot resolve transport pubkey for "<nametag>". No binding event found.` — the actual cause is the relay rejecting REQs with `[\"CLOSED\",\"<sub>\",\"error: Maximum concurrent subscription count reached\"]` and the SDK swallowing the rejection silently. Java sibling SDK has the same defects (filed separately as a parallel PR).

## Summary

- **Ping firehose** — `src/client/NostrClient.ts:447`. Keepalive REQ used `{limit: 1}` with no kinds/authors/#p, so after EOSE the relay streamed every event back through sub_id `\"ping\"` (NIP-01 live tail). ~30 KB/s/client of bandwidth and persistent per-connection sub-slot pressure. Scoped to `authors:[selfPubkey]`.
- **CLOSED handling — per-relay** — `src/client/NostrClient.ts` `handleClosedMessage`. The unfixed code dropped CLOSED frames entirely; my first fix removed the entry from the global `subscriptions` map, but Copilot pointed out that broke multi-relay clients (the same sub_id is shared across relays, so a CLOSED from one relay would silently drop EVENT/EOSE from healthy relays). The shipped behavior is per-relay: each `RelayConnection` has a `closedSubIds: Set<string>`, populated by `handleClosedMessage` and consulted by `resubscribeAll` so the rejection loop is broken on the sending relay only. The global `subscriptions` map is cleaned up only when the listener (e.g. `queryWithFirstSeenWins.onError`) explicitly calls `unsubscribe()` to give up across all relays. NIP-42 `auth-required` subs are re-issued post-AUTH by clearing `closedSubIds` immediately before the post-AUTH resubscribe.
- **Query settles on CLOSED** — `src/client/NostrClient.ts` `queryWithFirstSeenWins`. Did not pass `onError`, so relay-side rejections waited the full `queryTimeoutMs` (default 5 s) before resolving `null`. Now wires `onError`, settles with whatever was collected so far, and accepts an explicit listener-provided sub_id to guard against any future change to `subscribe()` that would invoke callbacks before its return value is bound.

NIP-01 conformance: `handleClosedMessage` accepts truncated `[\"CLOSED\",sub_id]` frames (message field is optional per spec); missing reason becomes `\"no reason provided\"`. Cleaned up a stray duplicate `getKeyManager` from the in-progress local diff. Updated the `setKeyManager` docstring to enumerate every consumer of the key manager, including the keepalive ping filter.

## Test plan

- [x] `npm run build:check` — typecheck clean
- [x] `npm run test:unit` — 331/331 (16 files, including 6 tests in `tests/unit/relay-fixes.test.ts` covering the ping filter shape, CLOSED listener notification, single-relay drop-after-CLOSED behavior, post-AUTH re-issue, and prompt query settle on CLOSED, plus the updated `tests/unit/reconnection.test.ts` ping-shape assertion)
- [x] `npm run test:integration` — 46 passed / 7 skipped (Docker-dependent), 4 new e2e tests in `tests/integration/relay-fixes-e2e.test.ts` against `wss://nostr-relay.testnet.unicity.network`:
  - positive control: `unichess` resolves in <1 s
  - negative control: random nametag returns `null` in <1 s
  - keepalive REQ has scoped filter; zero firehose events received in 5 s
  - synthetic CLOSED on a real connection: query settles in <2 s vs the 60 000 ms `queryTimeoutMs`

Note: `vitest.integration.config.ts` is new because the existing `vitest.config.ts` excluded `tests/integration/**`, which made `npm run test:integration` exit with \"No test files found\". The integration-config keeps the live-network tests opt-in (only runs from the integration entrypoint).